### PR TITLE
Locate endian header on Solaris

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -32,6 +32,8 @@
 #else
 #if defined(__APPLE__) || defined(__FreeBSD__)
 #include <machine/endian.h>
+#elif defined(sun) || defined(__sun)
+#include <sys/byteorder.h>
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
Looking into https://issues.apache.org/jira/browse/ARROW-11501, we found that this change was necessary to compile on Solaris (though perhaps not sufficient, haven't gotten that far yet).  