### PR TITLE
change anonymous namespace to namespace detail (#54)

### DIFF
--- a/include/fast_float/decimal_to_binary.h
+++ b/include/fast_float/decimal_to_binary.h
@@ -40,7 +40,7 @@ value128 compute_product_approximation(int64_t q, uint64_t w) {
   return firstproduct;
 }
 
-namespace {
+namespace detail {
 /**
  * For q in (0,350), we have that
  *  f = (((152170 + 65536) * q ) >> 16);
@@ -59,7 +59,7 @@ namespace {
   fastfloat_really_inline int power(int q)  noexcept  {
     return (((152170 + 65536) * q) >> 16) + 63;
   }
-} // namespace
+} // namespace detail
 
 
 // w * 10 ** q
@@ -114,7 +114,7 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
 
   answer.mantissa = product.high >> (upperbit + 64 - binary::mantissa_explicit_bits() - 3);
 
-  answer.power2 = int(power(int(q)) + upperbit - lz - binary::minimum_exponent());
+  answer.power2 = int(detail::power(int(q)) + upperbit - lz - binary::minimum_exponent());
   if (answer.power2 <= 0) { // we have a subnormal?
     // Here have that answer.power2 <= 0 so -answer.power2 >= 0
     if(-answer.power2 + 1 >= 64) { // if we have more than 64 bits below the minimum exponent, you have a zero for sure.

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -13,7 +13,7 @@
 namespace fast_float {
 
 
-namespace {
+namespace detail {
 /**
  * Special case +inf, -inf, nan, infinity, -infinity.
  * The case comparisons could be made much faster given that we know that the
@@ -78,7 +78,7 @@ fastfloat_really_inline void to_float(bool negative, adjusted_mantissa am, T &va
 #endif
 }
 
-} // namespace
+} // namespace detail
 
 
 
@@ -96,7 +96,7 @@ from_chars_result from_chars(const char *first, const char *last,
   }
   parsed_number_string pns = parse_number_string(first, last, fmt);
   if (!pns.valid) {
-    return parse_infnan(first, last, value);
+    return detail::parse_infnan(first, last, value);
   }
   answer.ec = std::errc(); // be optimistic
   answer.ptr = pns.lastmatch;
@@ -117,7 +117,7 @@ from_chars_result from_chars(const char *first, const char *last,
   // If we called compute_float<binary_format<T>>(pns.exponent, pns.mantissa) and we have an invalid power (am.power2 < 0),
   // then we need to go the long way around again. This is very uncommon.
   if(am.power2 < 0) { am = parse_long_mantissa<binary_format<T>>(first,last); }
-  to_float(pns.negative, am, value);
+  detail::to_float(pns.negative, am, value);
   return answer;
 }
 

--- a/include/fast_float/simple_decimal_conversion.h
+++ b/include/fast_float/simple_decimal_conversion.h
@@ -19,7 +19,7 @@
 
 namespace fast_float {
 
-namespace {
+namespace detail {
 
 // remove all final zeroes
 inline void trim(decimal &h) {
@@ -30,7 +30,7 @@ inline void trim(decimal &h) {
 
 
 
-uint32_t number_of_digits_decimal_left_shift(const decimal &h, uint32_t shift) {
+inline uint32_t number_of_digits_decimal_left_shift(const decimal &h, uint32_t shift) {
   shift &= 63;
   const static uint16_t number_of_digits_decimal_left_shift_table[65] = {
     0x0000, 0x0800, 0x0801, 0x0803, 0x1006, 0x1009, 0x100D, 0x1812, 0x1817,
@@ -123,7 +123,7 @@ uint32_t number_of_digits_decimal_left_shift(const decimal &h, uint32_t shift) {
   return num_new_digits;
 }
 
-uint64_t round(decimal &h) {
+inline uint64_t round(decimal &h) {
   if ((h.num_digits == 0) || (h.decimal_point < 0)) {
     return 0;
   } else if (h.decimal_point > 18) {
@@ -150,7 +150,7 @@ uint64_t round(decimal &h) {
 }
 
 // computes h * 2^-shift
-void decimal_left_shift(decimal &h, uint32_t shift) {
+inline void decimal_left_shift(decimal &h, uint32_t shift) {
   if (h.num_digits == 0) {
     return;
   }
@@ -192,7 +192,7 @@ void decimal_left_shift(decimal &h, uint32_t shift) {
 }
 
 // computes h * 2^shift
-void decimal_right_shift(decimal &h, uint32_t shift) {
+inline void decimal_right_shift(decimal &h, uint32_t shift) {
   uint32_t read_index = 0;
   uint32_t write_index = 0;
 
@@ -238,7 +238,7 @@ void decimal_right_shift(decimal &h, uint32_t shift) {
   trim(h);
 }
 
-} // end of anonymous namespace
+} // namespace detail
 
 template <typename binary>
 adjusted_mantissa compute_float(decimal &d) {
@@ -281,7 +281,7 @@ adjusted_mantissa compute_float(decimal &d) {
   while (d.decimal_point > 0) {
     uint32_t n = uint32_t(d.decimal_point);
     uint32_t shift = (n < num_powers) ? powers[n] : max_shift;
-    decimal_right_shift(d, shift);
+    detail::decimal_right_shift(d, shift);
     if (d.decimal_point < -decimal_point_range) {
       // should be zero
       answer.power2 = 0;
@@ -302,7 +302,7 @@ adjusted_mantissa compute_float(decimal &d) {
       uint32_t n = uint32_t(-d.decimal_point);
       shift = (n < num_powers) ? powers[n] : max_shift;
     }
-    decimal_left_shift(d, shift);
+    detail::decimal_left_shift(d, shift);
     if (d.decimal_point > decimal_point_range) {
       // we want to get infinity:
       answer.power2 = binary::infinite_power();
@@ -319,7 +319,7 @@ adjusted_mantissa compute_float(decimal &d) {
     if (n > max_shift) {
       n = max_shift;
     }
-    decimal_right_shift(d, n);
+    detail::decimal_right_shift(d, n);
     exp2 += int32_t(n);
   }
   if ((exp2 - minimum_exponent) >= binary::infinite_power()) {
@@ -329,15 +329,15 @@ adjusted_mantissa compute_float(decimal &d) {
   }
 
   const int mantissa_size_in_bits = binary::mantissa_explicit_bits() + 1;
-  decimal_left_shift(d, mantissa_size_in_bits);
+  detail::decimal_left_shift(d, mantissa_size_in_bits);
 
-  uint64_t mantissa = round(d);
+  uint64_t mantissa = detail::round(d);
   // It is possible that we have an overflow, in which case we need
   // to shift back.
   if(mantissa >= (uint64_t(1) << mantissa_size_in_bits)) {
-    decimal_right_shift(d, 1);
+    detail::decimal_right_shift(d, 1);
     exp2 += 1;
-    mantissa = round(d);
+    mantissa = detail::round(d);
     if ((exp2 - minimum_exponent) >= binary::infinite_power()) {
       answer.power2 = binary::infinite_power();
       answer.mantissa = 0;


### PR DESCRIPTION
As it was proposed in #54, this PR changes anonymous namespaces to `detail`, but only for functions.

There are still variables that get duplicated in compilation units, also outside of the anonymous namespace. The biggest of them is `power_of_five_128`. It'd think it might be UB, but IANAL (in particular not a C++ language lawyer).

For power_of_five I'd be for using the template trick that allows inline variables in C++11, as described in [this answer][1] and as [used in sajson][2].

[1]: https://stackoverflow.com/a/38043566/104453
[2]: https://github.com/chadaustin/sajson/blob/3f256a9b1771e480fe363fb7bef9e847de8eb92a/include/sajson.h#L137