### PR TITLE
Using inline globals when C++17 is detected.

### DIFF
--- a/include/fast_float/fast_table.h
+++ b/include/fast_float/fast_table.h
@@ -31,6 +31,8 @@ namespace fast_float {
 constexpr int smallest_power_of_five = -342;
 constexpr int largest_power_of_five = 308;
 // Powers of five from 5^-342 all the way to 5^308 rounded toward one.
+// For C++17, we define power_of_five_128 once.
+FASTFLOAT_CPLUSPLUS17_INLINE
 const uint64_t power_of_five_128[]= {
         0xeef453d6923bd65a,0x113faa2906a13b3f,
         0x9558b4661b6565f8,0x4ac7ca59a424c507,

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -62,6 +62,32 @@
 #define fastfloat_really_inline inline __attribute__((always_inline))
 #endif
 
+
+#ifndef __cplusplus
+#error fast_float requires a C++ compiler
+#endif
+
+#ifndef FASTFLOAT_CPLUSPLUS
+#if defined(_MSVC_LANG) && !defined(__clang__)
+#define FASTFLOAT_CPLUSPLUS (_MSC_VER == 1900 ? 201103L : _MSVC_LANG)
+#else
+#define FASTFLOAT_CPLUSPLUS __cplusplus
+#endif
+#endif
+
+// C++ 17
+#if !defined(FASTFLOAT_CPLUSPLUS17) && (FASTFLOAT_CPLUSPLUS >= 201703L)
+#define FASTFLOAT_CPLUSPLUS17 1
+#endif
+
+#ifndef FASTFLOAT_CPLUSPLUS17_INLINE
+#if FASTFLOAT_CPLUSPLUS17
+#define FASTFLOAT_CPLUSPLUS17_INLINE inline
+#else
+#define FASTFLOAT_CPLUSPLUS17_INLINE
+#endif
+#endif
+
 namespace fast_float {
 
 // Compares two ASCII strings in a case insensitive manner.


### PR DESCRIPTION
When C++17 is detected, we make sure that our array is an inline global constant.

cc @wojdyr 