### PR TITLE
Add support for other architectures.

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -17,7 +17,18 @@
      || defined(__MINGW32__))
 #define FASTFLOAT_32BIT
 #else
-#error Unknown platform (not 32-bit, not 64-bit?)
+  // Need to check incrementally, since SIZE_MAX is a size_t, avoid overflow.
+  // We can never tell the register width, but the SIZE_MAX is a good approximation.
+  // UINTPTR_MAX and INTPTR_MAX are optional, so avoid them for max portability.
+  #if SIZE_MAX == 0xffff
+    #error Unknown platform (16-bit, unsupported)
+  #elif SIZE_MAX == 0xffffffff
+    #define FASTFLOAT_32BIT
+  #elif SIZE_MAX == 0xffffffffffffffff
+    #define FASTFLOAT_64BIT
+  #else
+    #error Unknown platform (not 32-bit, not 64-bit?)
+  #endif
 #endif
 
 #if ((defined(_WIN32) || defined(_WIN64)) && !defined(__clang__))


### PR DESCRIPTION
Fixes #76.

This was tested via emulation on the following systems:
- alpha
- i686
- mips64r6el
- ppc64
- sh4
- arm64
- m68k
- mips
- ppc64le
- sparc64
- armel-armhf
- mips64
- mipsel
- ppc
- armel
- mips64el
- mipsr6
- riscv64
- hppa
- mips64r6
- mipsr6el
- s390x

All systems passed except for M68K and HPPA. For M68K, the only differences were the NaN values (which is trivial), while with HPPA, there was a core dump (more severe, but it's a rare architecture), and a new version has not been released in over 25 years.

The Dockerfile and CMake toolchains can be found [here](https://github.com/Alexhuszagh/toolchains).