### PR TITLE
Add support for MIPS64 and RISCV64 on CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   global:
     - fastfloat_DEPENDENCY_CACHE_DIR=$HOME/.dep_cache
 
+services:
+  - docker
 
 # the ppc64le and s390x images use cmake 3.10, but fast_float requires 3.11.
 # so we compile cmake from source in those images.
@@ -186,8 +188,22 @@ matrix:
         - SANITIZE="on"
       compiler: clang-10-sanitize
 
+    - arch: amd64
+      os: linux
+      env:
+        - TOOLCHAIN="mips64"
+
+    - arch: amd64
+      os: linux
+      env:
+        - TOOLCHAIN="riscv64"
+
 before_install:
   - eval "${COMPILER}"
+  - |
+    if [ "$TOOLCHAIN" != "" ] ; then
+      docker pull ahuszagh/cross:"$TOOLCHAIN"
+    fi
 
 install:
   - |
@@ -218,8 +234,9 @@ install:
   - ${CXX} --version
 
 script:
-  - mkdir build
-  - cd build
-  - cmake -DFASTFLOAT_TEST=ON  ..
-  - make -j2
-  - ctest --output-on-failure -R basictest
+  - |
+    if [ "$TOOLCHAIN" != "" ] ; then
+      docker run -v "$(pwd)":/ff ahuszagh/cross:"$TOOLCHAIN" /bin/bash -c "cd ff && ci/script.sh $TOOLCHAIN"
+    else
+      ci/script.sh
+    fi

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+TOOLCHAIN="$1"
+
+mkdir build
+cd build
+
+if [ "$TOOLCHAIN" != "" ] ; then
+    cmake -DFASTFLOAT_TEST=ON  .. -DCMAKE_TOOLCHAIN_FILE=/toolchains/"$TOOLCHAIN".cmake
+else
+    cmake -DFASTFLOAT_TEST=ON  ..
+fi
+make -j 2
+if [ "$TOOLCHAIN" != "" ] ; then
+  qemu-"$TOOLCHAIN" tests/basictest
+else
+  ctest --output-on-failure -R basictest
+fi


### PR DESCRIPTION
This fixes the [comments](https://github.com/fastfloat/fast_float/pull/77#issuecomment-847240467) on PR #77, by adding CI support for 2 of the most important architectures fixed by #77.

There are potential downsides here, in that it relies on Docker images [here](https://hub.docker.com/r/ahuszagh/cross/tags?page=1&ordering=last_updated), which are build from [Alexhuszagh/toolchains](https://github.com/Alexhuszagh/toolchains). This has a few disadvantages, since I am not a maintainer of `fast_float` (nor do I intend to be), but the CI would then depend on my own Docker images.

A few simple alternatives are:
1. Provide your own Docker images on Dockerhub.
2. Copy the Dockerfiles and build if `TOOLCHAIN` is set on each CI build.

The second would make the CI builds much slower, but would avoid requiring to make a free-tier Dockerhub account. I'm more than happy to provide Docker images, but I think it's important to highlight that this might not be desirable.