### PR TITLE
Single include script

### DIFF
--- a/.github/workflows/amalgamate-ubuntu20.yml
+++ b/.github/workflows/amalgamate-ubuntu20.yml
@@ -1,0 +1,25 @@
+name: Amalgamate Ubuntu 20.04 CI (GCC 9, 8)
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Legacy/x86 compilers cause CI failures.
+          #- {cxx: -DCMAKE_CXX_COMPILER=g++-8, arch:                         }
+          - {cxx:                           , arch:                         } # default=gcc9
+          #- {cxx:                           , arch: -DCMAKE_CXX_FLAGS="-m32"} # default=gcc9
+    steps:
+      - uses: actions/checkout@v2
+      - name: Compile with amalgamation
+        run: |
+          mkdir build &&
+          mkdir build/fast_float &&
+          python3 ./scripts/amalgamate.py > build/fast_float/fast_float.h &&
+          cp tests/string_test.cpp build/ &&
+          cd build &&
+          g++ string_test.cpp

--- a/.github/workflows/amalgamate-ubuntu20.yml
+++ b/.github/workflows/amalgamate-ubuntu20.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           mkdir build &&
           mkdir build/fast_float &&
-          python3 ./scripts/amalgamate.py > build/fast_float/fast_float.h &&
+          python3 ./script/amalgamate.py > build/fast_float/fast_float.h &&
           cp tests/string_test.cpp build/ &&
           cd build &&
           g++ string_test.cpp

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ Maksim Kita
 Marcin Wojdyr
 Neal Richardson
 Tim Paine
+Fabio Pellacini

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ target_link_libraries(myprogram PUBLIC fast_float)
 
 ```
 
+## Using as single header
+
+The script `amalgamate.py` may be used to generate a single header version of the library is so desired.
+Just run the script from the root directory of this repository. 
+You can customize the license type and output file is desired as described in the command line help.
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ target_link_libraries(myprogram PUBLIC fast_float)
 
 ## Using as single header
 
-The script `scripts/amalgamate.py` may be used to generate a single header 
+The script `script/amalgamate.py` may be used to generate a single header 
 version of the library if so desired.
 Just run the script from the root directory of this repository. 
 You can customize the license type and output file if desired as described in

--- a/README.md
+++ b/README.md
@@ -143,9 +143,11 @@ target_link_libraries(myprogram PUBLIC fast_float)
 
 ## Using as single header
 
-The script `amalgamate.py` may be used to generate a single header version of the library is so desired.
+The script `scripts/amalgamate.py` may be used to generate a single header 
+version of the library if so desired.
 Just run the script from the root directory of this repository. 
-You can customize the license type and output file is desired as described in the command line help.
+You can customize the license type and output file if desired as described in
+the command line help.
 
 ## Credit
 

--- a/script/amalgamate.py
+++ b/script/amalgamate.py
@@ -1,0 +1,56 @@
+# text parts
+processed_files = { }
+
+# authors
+for filename in ['AUTHORS', 'CONTRIBUTORS']:
+  with open(filename) as f:
+    text = ''
+    for line in f:
+      if filename == 'AUTHORS':
+        text += '// fast_float by ' + line
+      if filename == 'CONTRIBUTORS':
+        text += '// with contributions from ' + line
+    processed_files[filename] = text
+
+# licenses
+for filename in ['LICENSE-MIT', 'LICENSE-APACHE']:
+  with open(filename) as f:
+    text = ''
+    for line in f:
+      text += '// ' + line
+    processed_files[filename] = text
+
+# code
+for filename in [ 'fast_float.h', 'float_common.h', 'ascii_number.h', 
+                  'fast_table.h', 'decimal_to_binary.h', 'ascii_number.h', 
+                  'simple_decimal_conversion.h', 'parse_number.h']:
+  with open('include/fast_float/' + filename) as f:
+    text = ''
+    for line in f:
+      if line.startswith('#include "'): continue
+      text += line
+    processed_files[filename] = text
+
+# command line
+import argparse
+
+parser = argparse.ArgumentParser(description='Amalgamate fast_float.')
+parser.add_argument('--license', default='MIT', help='choose license')
+parser.add_argument('--output', default='', help='output file (stdout if none')
+
+args = parser.parse_args()
+
+text = '\n\n'.join([
+  processed_files['AUTHORS'], processed_files['CONTRIBUTORS'], 
+  processed_files['LICENSE-' + args.license],
+  processed_files['fast_float.h'], processed_files['float_common.h'], 
+  processed_files['ascii_number.h'], processed_files['fast_table.h'],
+  processed_files['decimal_to_binary.h'], processed_files['ascii_number.h'],
+  processed_files['simple_decimal_conversion.h'],
+  processed_files['parse_number.h']])
+
+if args.output:
+  with open(args.output, 'wt') as f:
+    f.write(text)
+else:
+  print(text)


### PR DESCRIPTION
This PR contains an amalgamate script that generates a single include file.
The script concatenates various files in the repository including authors, contributors, license (can choose from cli), and the various header files in the order of include, and removing local `#include` directives. The formatting I choose is just what I found easy to do on the first run by can be customized by changing easily by changing the script.

We can handle single includes in two manners: (1) provide a script that needs to be run by the library user, or (2) provide the amalgamated files ourselves. In the former case, the library is a bit harder to use. In the latter case, we need to add complexity to the CI setup. For example, do we include single header tests and installation? For now, I have decided to only add the script as in (1).  

There is a third option which is to always distribute `fast_float` as a single header since there are no downsides in this library. I would probably go this way if this were to be my library. But it is too big of a chance for a single PR.