### PR TITLE
Fixes #94, with unspecified behavior in pointer comparisons.

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstring>
+#include <iterator>
 
 #include "float_common.h"
 
@@ -115,10 +116,10 @@ parsed_number_string parse_number_string(const char *p, const char *pend, parse_
   if ((p != pend) && (*p == decimal_point)) {
     ++p;
   // Fast approach only tested under little endian systems
-  if ((p + 8 <= pend) && is_made_of_eight_digits_fast(p)) {
+  if ((std::distance(p, pend) >= 8) && is_made_of_eight_digits_fast(p)) {
     i = i * 100000000 + parse_eight_digits_unrolled(p); // in rare cases, this will overflow, but that's ok
     p += 8;
-    if ((p + 8 <= pend) && is_made_of_eight_digits_fast(p)) {
+    if ((std::distance(p, pend) >= 8) && is_made_of_eight_digits_fast(p)) {
       i = i * 100000000 + parse_eight_digits_unrolled(p); // in rare cases, this will overflow, but that's ok
       p += 8;
     }
@@ -254,7 +255,7 @@ fastfloat_really_inline decimal parse_decimal(const char *p, const char *pend, p
     }
     // We expect that this loop will often take the bulk of the running time
     // because when a value has lots of digits, these digits often
-    while ((p + 8 <= pend) && (answer.num_digits + 8 < max_digits)) {
+    while ((std::distance(p, pend) >= 8) && (answer.num_digits + 8 < max_digits)) {
       uint64_t val = read_u64(p);
       if(! is_made_of_eight_digits_fast(val)) { break; }
       // We have eight digits, process them in one go!


### PR DESCRIPTION
Fixes #94, by replacing unspecified pointer comparisons with well-defined behavior using `std::distance` with the current pointer and the pointer to one-past-the-end of the array.

As a simple schematic of why this is important, we have:

```text
| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
| x | x | x | p | - | - | - | - | - | - | - | - |
```

As you can if we have already the `x` digits, with an array with `10` elements, and try to compare `p+8` to `pend`, we compare after the end of the array. This could optimize to being always true, or the integer arithmetic could wrap, leading to another always-true comparison.

The conformant solution is therefore: `std::distance(p, pend) >= 8`, which also [optimizes](https://godbolt.org/z/aqvThfqac) well, so there's no issue of a performance hit (just ensuring the compiler does not cause an undesired optimizations due to unspecified behavior, such as a potential infinite loop).