### PR TITLE
Remove unneeded includes

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -1,7 +1,6 @@
 #ifndef FASTFLOAT_ASCII_NUMBER_H
 #define FASTFLOAT_ASCII_NUMBER_H
 
-#include <cstdio>
 #include <cctype>
 #include <cstdint>
 #include <cstring>

--- a/include/fast_float/decimal_to_binary.h
+++ b/include/fast_float/decimal_to_binary.h
@@ -7,7 +7,6 @@
 #include <cinttypes>
 #include <cmath>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 

--- a/include/fast_float/fast_table.h
+++ b/include/fast_float/fast_table.h
@@ -1,5 +1,6 @@
 #ifndef FASTFLOAT_FAST_TABLE_H
 #define FASTFLOAT_FAST_TABLE_H
+
 #include <cstdint>
 
 namespace fast_float {

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -1,10 +1,10 @@
 #ifndef FASTFLOAT_PARSE_NUMBER_H
 #define FASTFLOAT_PARSE_NUMBER_H
+
 #include "ascii_number.h"
 #include "decimal_to_binary.h"
 #include "simple_decimal_conversion.h"
 
-#include <cassert>
 #include <cmath>
 #include <cstring>
 #include <limits>


### PR DESCRIPTION
From issue #97 :
- remove `<cstdio>` includes, they seem unused (I assume they are relicts from debugging), compiles without them
- remove `<cassert>` include from `parse_number.h`, there is no assert (only static_assert)
- add esthetic newlines between include guards and includes 

Is `fast_table.h` auto generated? Apparently I added a newline to the last line (like all other files have). 