### PR TITLE
Testing changes and fixes

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ endfunction(fast_float_add_cpp_test)
 fast_float_add_cpp_test(example_test)
 fast_float_add_cpp_test(example_comma_test)
 fast_float_add_cpp_test(basictest)
+fast_float_add_cpp_test(long_test)
 fast_float_add_cpp_test(powersoffive_hardround)
 fast_float_add_cpp_test(string_test)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,17 +56,17 @@ endfunction(fast_float_add_cpp_test)
 fast_float_add_cpp_test(example_test)
 fast_float_add_cpp_test(example_comma_test)
 fast_float_add_cpp_test(basictest)
+fast_float_add_cpp_test(powersoffive_hardround)
+fast_float_add_cpp_test(string_test)
 
 
 
 option(FASTFLOAT_EXHAUSTIVE "Exhaustive tests" OFF)
 
 if (FASTFLOAT_EXHAUSTIVE)
-  fast_float_add_cpp_test(powersoffive_hardround)
   fast_float_add_cpp_test(short_random_string)
   fast_float_add_cpp_test(exhaustive32_midpoint)
   fast_float_add_cpp_test(random_string)
-  fast_float_add_cpp_test(string_test)
   fast_float_add_cpp_test(exhaustive32)
   fast_float_add_cpp_test(exhaustive32_64)
   fast_float_add_cpp_test(long_exhaustive32)

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -3,8 +3,13 @@
 #include <doctest/doctest.h>
 
 #include "fast_float/fast_float.h"
+#include <cmath>
+#include <cstdio>
 #include <iomanip>
+#include <ios>
+#include <limits>
 #include <string>
+#include <system_error>
 
 #ifndef SUPPLEMENTAL_TEST_DATA_DIR
 #define SUPPLEMENTAL_TEST_DATA_DIR "data/"

--- a/tests/example_comma_test.cpp
+++ b/tests/example_comma_test.cpp
@@ -1,6 +1,8 @@
 
 #include "fast_float/fast_float.h"
 #include <iostream>
+#include <string>
+#include <system_error>
  
 int main() {
     const std::string input =  "3,1416 xyz ";

--- a/tests/example_test.cpp
+++ b/tests/example_test.cpp
@@ -1,6 +1,8 @@
 
 #include "fast_float/fast_float.h"
 #include <iostream>
+#include <string>
+#include <system_error>
  
 int main() {
     const std::string input =  "3.1416 xyz ";

--- a/tests/exhaustive32.cpp
+++ b/tests/exhaustive32.cpp
@@ -1,9 +1,13 @@
 
 #include "fast_float/fast_float.h"
 
-#include <iostream>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
+#include <ios>
+#include <iostream>
+#include <limits>
+#include <system_error>
 
 template <typename T> char *to_string(T d, char *buffer) {
   auto written = std::snprintf(buffer, 64, "%.*e",

--- a/tests/exhaustive32_64.cpp
+++ b/tests/exhaustive32_64.cpp
@@ -1,9 +1,14 @@
 
 #include "fast_float/fast_float.h"
 
-#include <iostream>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
+#include <ios>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <system_error>
 
 template <typename T> char *to_string(T d, char *buffer) {
   auto written = std::snprintf(buffer, 64, "%.*e",

--- a/tests/exhaustive32_midpoint.cpp
+++ b/tests/exhaustive32_midpoint.cpp
@@ -1,8 +1,12 @@
 #include "fast_float/fast_float.h"
 
-#include <iostream>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
+#include <ios>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
 
 #if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__) 
 // Anything at all that is related to cygwin, msys and so forth will

--- a/tests/long_exhaustive32.cpp
+++ b/tests/long_exhaustive32.cpp
@@ -1,9 +1,12 @@
 
 #include "fast_float/fast_float.h"
 
-#include <iostream>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
+#include <ios>
+#include <iostream>
+#include <system_error>
 
 template <typename T> char *to_string(T d, char *buffer) {
   auto written = std::snprintf(buffer, 128, "%.*e",

--- a/tests/long_exhaustive32_64.cpp
+++ b/tests/long_exhaustive32_64.cpp
@@ -1,8 +1,10 @@
 #include "fast_float/fast_float.h"
 
-#include <iostream>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
+#include <ios>
+#include <iostream>
 
 template <typename T> char *to_string(T d, char *buffer) {
   auto written = std::snprintf(buffer, 128, "%.*e",

--- a/tests/long_random64.cpp
+++ b/tests/long_random64.cpp
@@ -1,8 +1,11 @@
 #include "fast_float/fast_float.h"
 
-#include <iostream>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
+#include <ios>
+#include <iostream>
+#include <system_error>
 
 template <typename T> char *to_string(T d, char *buffer) {
   auto written = std::snprintf(buffer, 128, "%.*e",

--- a/tests/long_test.cpp
+++ b/tests/long_test.cpp
@@ -1,6 +1,10 @@
 #include "fast_float/fast_float.h"
 
+#include <cctype>
 #include <iostream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
 #include <vector>
 
 inline void Assert(bool Assertion) {

--- a/tests/long_test.cpp
+++ b/tests/long_test.cpp
@@ -1,5 +1,6 @@
 #include "fast_float/fast_float.h"
 
+#include <iostream>
 #include <vector>
 
 inline void Assert(bool Assertion) {
@@ -14,6 +15,7 @@ bool test() {
   const char * end = input.data() + input.size();
   for(size_t i = 0; i < answers.size(); i++) {
     T result_value;
+    while((begin < end) && (std::isspace(*begin))) { begin++; }
     auto result = fast_float::from_chars(begin, end,
                                       result_value);
     if (result.ec != std::errc()) {

--- a/tests/powersoffive_hardround.cpp
+++ b/tests/powersoffive_hardround.cpp
@@ -1,8 +1,12 @@
 #include "fast_float/fast_float.h"
 
+#include <ios>
 #include <iostream>
 #include <random>
 #include <sstream>
+#include <string>
+#include <system_error>
+#include <utility>
 #include <vector>
 
 
@@ -11,7 +15,6 @@
 // always use this fallback because we cannot rely on it behaving as normal
 // gcc.
 #include <locale>
-#include <sstream>
 // workaround for CYGWIN
 double cygwin_strtod_l(const char* start, char** end) {
     double d;

--- a/tests/random64.cpp
+++ b/tests/random64.cpp
@@ -1,8 +1,12 @@
 #include "fast_float/fast_float.h"
 
-#include <iostream>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
+#include <ios>
+#include <iostream>
+#include <limits>
+#include <system_error>
 
 template <typename T> char *to_string(T d, char *buffer) {
   auto written = std::snprintf(buffer, 64, "%.*e",

--- a/tests/random_string.cpp
+++ b/tests/random_string.cpp
@@ -1,8 +1,11 @@
 #include "fast_float/fast_float.h"
 
-#include <iostream>
 #include <cstdint>
+#include <ios>
+#include <iostream>
 #include <random>
+#include <system_error>
+#include <utility>
 
 #if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__)  || defined(sun) || defined(__sun)
 // Anything at all that is related to cygwin, msys and so forth will

--- a/tests/short_random_string.cpp
+++ b/tests/short_random_string.cpp
@@ -1,7 +1,11 @@
 #include "fast_float/fast_float.h"
-#include <iostream>
+
 #include <cstdint>
+#include <ios>
+#include <iostream>
 #include <random>
+#include <system_error>
+#include <utility>
 
 #if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__)  || defined(sun) || defined(__sun)
 // Anything at all that is related to cygwin, msys and so forth will

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -1,5 +1,12 @@
 #include "fast_float/fast_float.h"
+
+#include <cctype>
+#include <cstdio>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <system_error>
 #include <vector>
 
 #if defined(__CYGWIN__) || defined(__MINGW32__) || defined(__MINGW64__)  || defined(sun) || defined(__sun)


### PR DESCRIPTION
This moves tests with ~subsecond durations from the exhaustive test suite (which does not run in CI) to the default suite (which does). We also configure `long_test.cpp` (which was abandoned) to be in the default test suite and apply two fixes to it to make it compile and pass (`#include <iostream>` to make `std::cerr` etc. be defined, and apply the same whitespace-skipping fix we used in `string_test.cpp`).