### PR TITLE
constexpr fixes

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -121,8 +121,9 @@ template <typename T>
 struct span {
   const T* ptr;
   size_t length;
-  span(const T* _ptr, size_t _length) : ptr(_ptr), length(_length) {}
-  span() : ptr(nullptr), length(0) {}
+  CXX20_CONSTEXPR span(const T* _ptr, size_t _length)
+      : ptr(_ptr), length(_length) {}
+  CXX20_CONSTEXPR span() : ptr(nullptr), length(0) {}
 
   constexpr size_t len() const noexcept {
     return length;
@@ -137,8 +138,9 @@ struct span {
 struct value128 {
   uint64_t low;
   uint64_t high;
-  value128(uint64_t _low, uint64_t _high) : low(_low), high(_high) {}
-  value128() : low(0), high(0) {}
+  CXX20_CONSTEXPR value128(uint64_t _low, uint64_t _high)
+      : low(_low), high(_high) {}
+  CXX20_CONSTEXPR value128() : low(0), high(0) {}
 };
 
 /* result might be undefined when input_num is zero */

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -136,9 +136,13 @@ static_assert(tryParse("1.0") == 1.0);
 static_assert(tryParse("2.0") == 2.0);
 static_assert(tryParse("3.14156") == 3.14156);
 static_assert(tryParse("3.14156") != 3.1415600000001);
-#if !defined(_MSVC_LANG)
-static_assert(std::isnan(tryParse("hellothere")));    // technically isnan is not constexpr but GCC and clang allow it
-#endif
+
+
+TEST_CASE("parse_nan_constexpr") {
+  // technically isnan is not constexpr, even though some versions of GCC
+  // and clang allow it
+  CHECK(std::isnan(tryParse("hellothere")));
+}
 
 #endif  //#if HAS_CXX20_CONSTEXPR
 


### PR DESCRIPTION
These changes seem to be required to make the library work with the newest clang version (currently clang-14 nightly, 2021-09-15 build) in my project. The arguments provided to clang by the build system all seem reasonable and normal:

```
/usr/bin/clang
-U_FORTIFY_SOURCE
-fstack-protector
-Wall
-Wthread-safety
-Wself-assign
-Wunused-but-set-parameter
-Wno-free-nonheap-object
-fcolor-diagnostics
-fno-omit-frame-pointer
'-std=c++0x'
-MD
-MF bazel-out/k8-fastbuild/bin/misc/_objs/fastfloat_check/fastfloat_check.pic.d
'-frandom-seed=bazel-out/k8-fastbuild/bin/misc/_objs/fastfloat_check/fastfloat_check.pic.o'
-fPIC
-iquote .
-iquote bazel-out/k8-fastbuild/bin
-iquote external/bazel_tools
-iquote bazel-out/k8-fastbuild/bin/external/bazel_tools
-Ibazel-out/k8-fastbuild/bin/third_party/fastfloat/_virtual_includes/fastfloat
'-std=c++20'
'-Werror=reorder'
'-Werror=return-type'
'-Werror=self-move'
'-stdlib=libc++'
-no-canonical-prefixes
-Wno-builtin-macro-redefined
'-D__DATE__="redacted"'
'-D__TIMESTAMP__="redacted"'
'-D__TIME__="redacted"'
-c misc/fastfloat_check.cc
-o bazel-out/k8-fastbuild/bin/misc/_objs/fastfloat_check/fastfloat_check.pic.o
```

...but as of (i believe) a recent update to clang it is now much pickier about `constexpr` rules. it's not clear to me exactly what exactly the tipping point was on my system, but its complaints appear valid in the standard.

in addition to these changes, it appears that `write_u64` is never used anywhere. It may be better to delete this function entirely.

i do not think this should necessarily be merged immediately, as it might be better to wait and see whether this shakes out in another couple nightly releases.