### PR TITLE
Fix deduction failure for std::min call

### DIFF
--- a/include/fast_float/digit_comparison.h
+++ b/include/fast_float/digit_comparison.h
@@ -86,7 +86,7 @@ fastfloat_really_inline void round(adjusted_mantissa& am, callback cb) noexcept 
   if (-am.power2 >= mantissa_shift) {
     // have a denormal float
     int32_t shift = -am.power2 + 1;
-    cb(am, std::min(shift, 64));
+    cb(am, std::min<int32_t>(shift, 64));
     // check for round-up: if rounding-nearest carried us to the hidden bit.
     am.power2 = (am.mantissa < (uint64_t(1) << binary_format<T>::mantissa_explicit_bits())) ? 0 : 1;
     return;


### PR DESCRIPTION
This assumes that the literal `64` of type `int` has the same type as the `int32_t` typedef, which is never true for targets with 16-bit `int`, and isn't guaranteed to be true even with 32-bit `int`.