### PR TITLE
Make endianness detection more portable

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -41,7 +41,9 @@
 #define FASTFLOAT_VISUAL_STUDIO 1
 #endif
 
-#ifdef _WIN32
+#if defined __BYTE_ORDER__ && defined __ORDER_BIG_ENDIAN__
+#define FASTFLOAT_IS_BIG_ENDIAN (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#elif defined _WIN32
 #define FASTFLOAT_IS_BIG_ENDIAN 0
 #else
 #if defined(__APPLE__) || defined(__FreeBSD__)


### PR DESCRIPTION
The current check for endianness fails on platforms using newlib as the
C library, because it provides <machine/endian.h> not <endian.h>. This
could be fixed by adding `|| defined(__NEWLIB__)` to the check for
targets that provide <machine/endian.h> (i.e. BSD-like targets).

A more portable solution is to just check if the compiler has already
defined the necessary macros (which is true for GCC and Clang and Intel,
at least). Then no header is needed, and it works for platforms that
aren't explicitly listed in the conditionals.