### PR TITLE
Export CMake targets as architecture independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,11 @@ set(FASTFLOAT_VERSION_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/module/FastFloatConfig
 set(FASTFLOAT_PROJECT_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/module/FastFloatConfig.cmake")
 set(FASTFLOAT_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/FastFloat")
 
-write_basic_package_version_file("${FASTFLOAT_VERSION_CONFIG}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion)
+if(${CMAKE_VERSION} VERSION_LESS "3.14")
+  write_basic_package_version_file("${FASTFLOAT_VERSION_CONFIG}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion)
+else()
+  write_basic_package_version_file("${FASTFLOAT_VERSION_CONFIG}" VERSION ${PROJECT_VERSION} COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+endif()
 configure_package_config_file("cmake/config.cmake.in"
                               "${FASTFLOAT_PROJECT_CONFIG}"
                               INSTALL_DESTINATION "${FASTFLOAT_CONFIG_INSTALL_DIR}")


### PR DESCRIPTION
Export CMake targets as architecture independent.

This will fix issues when package was built on 32-bit and then reused on 64-bit architectures and fixes the following issues:

```
CMake Error at CMakeLists.txt:52 (find_package):
  Could not find a configuration file for package "FastFloat" that is
  compatible with requested version "".

  The following configuration files were considered but not accepted:

    /usr/share/cmake/FastFloat/FastFloatConfig.cmake, version: 3.4.0 (32bit)
```

`ARCH_INDEPENDENT` requires CMake 3.14 or higher, that's why we use version check.