### PR TITLE
update actions/checkout in GitHub Actions to v3

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -6,7 +6,7 @@ jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: start docker
         run: |
           docker run -w /src -dit --name alpine -v $PWD:/src alpine:latest

--- a/.github/workflows/amalgamate-ubuntu20.yml
+++ b/.github/workflows/amalgamate-ubuntu20.yml
@@ -14,7 +14,7 @@ jobs:
           - {cxx:                           , arch:                         } # default=gcc9
           #- {cxx:                           , arch: -DCMAKE_CXX_FLAGS="-m32"} # default=gcc9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Compile with amalgamation
         run: |
           mkdir build &&

--- a/.github/workflows/msys2-clang.yml
+++ b/.github/workflows/msys2-clang.yml
@@ -23,7 +23,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
         with:
           update: true

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -29,7 +29,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: msys2/setup-msys2@v2
         with:
           update: true

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -15,7 +15,7 @@ jobs:
           - {cxx:                           , arch:                         } # default=gcc7
           #- {cxx:                           , arch: -DCMAKE_CXX_FLAGS="-m32"} # default=gcc7
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.4
         with:

--- a/.github/workflows/ubuntu20-cxx20.yml
+++ b/.github/workflows/ubuntu20-cxx20.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -14,7 +14,7 @@ jobs:
           - {cxx:                           , arch:                         } # default=gcc9
           #- {cxx:                           , arch: -DCMAKE_CXX_FLAGS="-m32"} # default=gcc9
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/vs17-arm-ci.yml
+++ b/.github/workflows/vs17-arm-ci.yml
@@ -14,7 +14,7 @@ jobs:
           - {arch: ARM64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use cmake
         run: |
           cmake -A ${{ matrix.arch }} -DCMAKE_CROSSCOMPILING=1 -DFASTFLOAT_TEST=ON -B build  &&

--- a/.github/workflows/vs17-ci.yml
+++ b/.github/workflows/vs17-ci.yml
@@ -14,7 +14,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -14,7 +14,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Configure
         run: |
           mkdir build

--- a/.github/workflows/vs17-cxx20.yml
+++ b/.github/workflows/vs17-cxx20.yml
@@ -14,7 +14,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Use cmake
         run: |
           mkdir build &&


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflow to its newest version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.0.2
> - [Add input `set-safe-directory`](https://github.com/actions/checkout/pull/770)
>
> ## v3.0.1
> - [Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`](https://github.com/actions/checkout/pull/762)
> - [Bumped various npm package versions](https://github.com/actions/checkout/pull/744)
>
> ## v3.0.0
>
> - [Update to node 16](https://github.com/actions/checkout/pull/689)

As far as I can tell this should all be backwards compatible, so I do not expect any breakage.