### PR TITLE
🔨 add library ALIAS FastFloat::fast_float

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 
 
 add_library(fast_float INTERFACE)
+add_library(FastFloat::fast_float ALIAS fast_float)
 target_include_directories(
   fast_float
   INTERFACE


### PR DESCRIPTION
This give same target name if library is found with find_package, or added via add_subdirectory