### PR TITLE
Don't use __umulh() with MinGW on ARM64

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -183,8 +183,9 @@ fastfloat_really_inline uint64_t _umul128(uint64_t ab, uint64_t cd,
 fastfloat_really_inline value128 full_multiplication(uint64_t a,
                                                      uint64_t b) {
   value128 answer;
-#ifdef _M_ARM64
+#if defined(_M_ARM64) && !defined(__MINGW32__)
   // ARM64 has native support for 64-bit multiplications, no need to emulate
+  // But MinGW on ARM64 doesn't have native support for 64-bit multiplications
   answer.high = __umulh(a, b);
   answer.low = a * b;
 #elif defined(FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))


### PR DESCRIPTION
I'm not familiar with MinGW on ARM64 but it seems that `__umulh()` isn't available with MinGW on ARM64.
See also: https://github.com/msys2/MINGW-packages/pull/12508

Note that `__MINGW32__` is defined with both of 32bit and 64bit MinGW.