### PR TITLE
Conditional Clinger's fast path

### DIFF
--- a/.github/workflows/ubuntu20-fastmath.yml
+++ b/.github/workflows/ubuntu20-fastmath.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 20.04 CI (GCC 9)
+name: Ubuntu 20.04 CI (GCC 9, fast-math)
 
 on: [push, pull_request]
 

--- a/.github/workflows/ubuntu20-fastmath.yml
+++ b/.github/workflows/ubuntu20-fastmath.yml
@@ -1,0 +1,18 @@
+name: Ubuntu 20.04 CI (GCC 9)
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use cmake
+        run: |
+          mkdir build &&
+          cd build &&
+          cmake -DCMAKE_CXX_FLAGS="-ffast-math" -DFASTFLOAT_TEST=ON ..  &&
+          cmake --build .   &&
+          ctest --output-on-failure

--- a/include/fast_float/bigint.h
+++ b/include/fast_float/bigint.h
@@ -17,7 +17,7 @@ namespace fast_float {
 // we might have platforms where `CHAR_BIT` is not 8, so let's avoid
 // doing `8 * sizeof(limb)`.
 #if defined(FASTFLOAT_64BIT) && !defined(__sparc)
-#define FASTFLOAT_64BIT_LIMB
+#define FASTFLOAT_64BIT_LIMB 1
 typedef uint64_t limb;
 constexpr size_t limb_bits = 64;
 #else

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -12,11 +12,11 @@
        || defined(__MINGW64__)                                          \
        || defined(__s390x__)                                            \
        || (defined(__ppc64__) || defined(__PPC64__) || defined(__ppc64le__) || defined(__PPC64LE__)) )
-#define FASTFLOAT_64BIT
+#define FASTFLOAT_64BIT 1
 #elif (defined(__i386) || defined(__i386__) || defined(_M_IX86)   \
      || defined(__arm__) || defined(_M_ARM)                   \
      || defined(__MINGW32__) || defined(__EMSCRIPTEN__))
-#define FASTFLOAT_32BIT
+#define FASTFLOAT_32BIT 1
 #else
   // Need to check incrementally, since SIZE_MAX is a size_t, avoid overflow.
   // We can never tell the register width, but the SIZE_MAX is a good approximation.
@@ -24,9 +24,9 @@
   #if SIZE_MAX == 0xffff
     #error Unknown platform (16-bit, unsupported)
   #elif SIZE_MAX == 0xffffffff
-    #define FASTFLOAT_32BIT
+    #define FASTFLOAT_32BIT 1
   #elif SIZE_MAX == 0xffffffffffffffff
-    #define FASTFLOAT_64BIT
+    #define FASTFLOAT_64BIT 1
   #else
     #error Unknown platform (not 32-bit, not 64-bit?)
   #endif

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -80,7 +80,8 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   // at compile-time.
   // There might be other ways to prevent compile-time optimizations (e.g., asm).
   // The value does not need to be std::numeric_limits<float>::min(), any small
-  // value so that 1 + x should round to 1 would do.
+  // value so that 1 + x should round to 1 would do (after accounting for excess
+  // precision, as in 387).
   static volatile float fmin = std::numeric_limits<float>::min();
   //
   // Explanation:

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -135,7 +135,12 @@ from_chars_result from_chars_advanced(const char *first, const char *last,
     // We do not have that fegetround() == FE_TONEAREST.
     // Next is a modified Clinger's fast path, inspired by Jakub Jelínek's proposal
     if (pns.exponent >= 0 && pns.exponent <= binary_format<T>::max_exponent_fast_path() && pns.mantissa <=binary_format<T>::max_mantissa_fast_path(pns.exponent) && !pns.too_many_digits) {
+#if (defined(_WIN32) && defined(__clang__))
+      // 32-bit ClangCL maps 0 to -0.0 when fegetround() == FE_DOWNWARD
+      value = pns.mantissa ? T(pns.mantissa) : 0.0;
+#else
       value = T(pns.mantissa);
+#endif
       value = value * binary_format<T>::exact_power_of_ten(pns.exponent);
       if (pns.negative) { value = -value; }
       return answer;

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -81,7 +81,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   // There might be other ways to prevent compile-time optimizations (e.g., asm).
   // The value does not need to be std::numeric_limits<float>::min(), any small
   // value so that 1 + x should round to 1 would do (after accounting for excess
-  // precision, as in 387).
+  // precision, as in 387 instructions).
   static volatile float fmin = std::numeric_limits<float>::min();
   float fmini = fmin; // we copy it so that it gets loaded at most once.
   //
@@ -90,19 +90,12 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   // fmin + 1.0f == 1.0f - fmin.
   //
   // FE_UPWARD:
-  //  fmin + 1.0f = 0x1.00001 (1.00001)
-  //  1.0f - fmin = 0x1 (1)
+  //  fmin + 1.0f > 1
+  //  1.0f - fmin == 1
   //
   // FE_DOWNWARD or  FE_TOWARDZERO:
-  //  fmin + 1.0f = 0x1 (1)
-  //  1.0f - fmin = 0x0.999999 (0.999999)
-  //
-  //  fmin + 1.0f = 0x1 (1)
-  //  1.0f - fmin = 0x0.999999 (0.999999)
-  //
-  // FE_TONEAREST:
-  //  fmin + 1.0f = 0x1 (1)
-  //  1.0f - fmin = 0x1 (1)
+  //  fmin + 1.0f == 1
+  //  1.0f - fmin < 1
   //
   // Note: This may fail to be accurate if fast-math has been
   // enabled, as rounding conventions may not apply.

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -83,6 +83,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   // value so that 1 + x should round to 1 would do (after accounting for excess
   // precision, as in 387).
   static volatile float fmin = std::numeric_limits<float>::min();
+  float fmini = fmin; // we copy it so that it gets loaded at most once.
   //
   // Explanation:
   // Only when fegetround() == FE_TONEAREST do we have that
@@ -105,7 +106,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   //
   // Note: This may fail to be accurate if fast-math has been
   // enabled, as rounding conventions may not apply.
-  return (fmin + 1.0f == 1.0f - fmin);
+  return (fmini + 1.0f == 1.0f - fmini);
 }
 
 } // namespace detail

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -135,13 +135,14 @@ from_chars_result from_chars_advanced(const char *first, const char *last,
     // We do not have that fegetround() == FE_TONEAREST.
     // Next is a modified Clinger's fast path, inspired by Jakub Jelínek's proposal
     if (pns.exponent >= 0 && pns.exponent <= binary_format<T>::max_exponent_fast_path() && pns.mantissa <=binary_format<T>::max_mantissa_fast_path(pns.exponent) && !pns.too_many_digits) {
-#if (defined(_WIN32) && defined(__clang__))
-      // 32-bit ClangCL maps 0 to -0.0 when fegetround() == FE_DOWNWARD
-      value = pns.mantissa ? T(pns.mantissa) : 0.0;
-#else
-      value = T(pns.mantissa);
+#if (defined(_MSC_VER) && defined(__clang__))
+      // ClangCL may map 0 to -0.0 when fegetround() == FE_DOWNWARD
+      if(pns.mantissa == 0) {
+        value = 0;
+        return answer;
+      }
 #endif
-      value = value * binary_format<T>::exact_power_of_ten(pns.exponent);
+      value = T(pns.mantissa) * binary_format<T>::exact_power_of_ten(pns.exponent);
       if (pns.negative) { value = -value; }
       return answer;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ option(SYSTEM_DOCTEST "Use system copy of doctest" OFF)
 if (NOT SYSTEM_DOCTEST)
   FetchContent_Declare(doctest
     GIT_REPOSITORY https://github.com/onqtam/doctest.git
-    GIT_TAG 2.4.6)
+    GIT_TAG v2.4.9)
 endif()
 FetchContent_Declare(supplemental_test_files
   GIT_REPOSITORY https://github.com/fastfloat/supplemental_test_files.git

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -141,11 +141,15 @@ bool check_file(std::string file_name) {
           // Compare with expected results
           if (float32_parsed != float32) {
             std::cout << "bad 32 " << str << std::endl;
+            std::cout << "parsed = " << iHexAndDec(float32_parsed) << ", expectd = " << iHexAndDec(float32) << std::endl;
+            std::cout << "fesetround: " << round_name(d) << std::endl;
             fesetround(FE_TONEAREST);
             return false;
           }
           if (float64_parsed != float64) {
             std::cout << "bad 64 " << str << std::endl;
+            std::cout << "parsed = " << iHexAndDec(float64_parsed) << ", expectd = " << iHexAndDec(float64) << std::endl;
+            std::cout << "fesetround: " << round_name(d) << std::endl;
             fesetround(FE_TONEAREST);
             return false;
           }

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -98,6 +98,36 @@ const char * round_name(int d) {
 
 }
 
+
+TEST_CASE("parse_zero") {
+  //
+  // If this function fails, we may be left in a non-standard rounding state.
+  //
+  const char * zero = "0";
+  double f = 0;
+  fesetround(FE_UPWARD);
+  auto r1 = fast_float::from_chars(zero, zero + 1, f);
+  CHECK(r1.ec == std::errc());
+  std::cout << "FE_UPWARD parsed zero as " << iHexAndDec(f) << std::endl;
+  CHECK(f == 0);
+  fesetround(FE_TOWARDZERO);
+  auto r2 = fast_float::from_chars(zero, zero + 1, f);
+  CHECK(r2.ec == std::errc());
+  std::cout << "FE_TOWARDZERO parsed zero as " << iHexAndDec(f) << std::endl;
+  CHECK(f == 0);
+  fesetround(FE_DOWNWARD);
+  auto r3 = fast_float::from_chars(zero, zero + 1, f);
+  CHECK(r3.ec == std::errc());
+  std::cout << "FE_DOWNWARD parsed zero as " << iHexAndDec(f) << std::endl;
+  CHECK(f == 0);
+  fesetround(FE_TONEAREST);
+  auto r4 = fast_float::from_chars(zero, zero + 1, f);
+  CHECK(r4.ec == std::errc());
+  std::cout << "FE_TONEAREST parsed zero as " << iHexAndDec(f) << std::endl;
+  CHECK(f == 0);
+}
+
+
 // return true on success
 bool check_file(std::string file_name) {
   std::cout << "Checking " << file_name << std::endl;

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -48,13 +48,66 @@
 #define fHexAndDec(v) std::hexfloat << (v) << " (" << std::defaultfloat << (v) << ")"
 
 
-// C++ 17 because it is otherwise annoying to browse all files in a directory.
-// We also only run these tests on little endian systems.
-#if (FASTFLOAT_CPLUSPLUS >= 201703L) && (FASTFLOAT_IS_BIG_ENDIAN == 0) && !defined(FASTFLOAT_ODDPLATFORM)
+const char * round_name(int d) {
+  switch(d) {
+    case FE_UPWARD:
+      return "FE_UPWARD";
+    case FE_DOWNWARD:
+      return "FE_DOWNWARD";
+    case FE_TOWARDZERO:
+      return "FE_TOWARDZERO";
+    case FE_TONEAREST:
+      return "FE_TONEAREST";
+    default:
+      return "UNKNOWN";
+  }
+}
 
-#include <iostream>
-#include <filesystem>
-#include <charconv>
+
+#define FASTFLOAT_STR(x)   #x
+#define SHOW_DEFINE(x) printf("%s='%s'\n", #x, FASTFLOAT_STR(x))
+
+TEST_CASE("system_info") {
+    std::cout << "system info:" << std::endl;
+#ifdef _MSC_VER
+    SHOW_DEFINE(_MSC_VER);
+#endif
+#ifdef FASTFLOAT_64BIT_LIMB
+    SHOW_DEFINE(FASTFLOAT_64BIT_LIMB);
+#endif
+#ifdef __clang__
+    SHOW_DEFINE(__clang__);
+#endif
+#ifdef FASTFLOAT_VISUAL_STUDIO
+    SHOW_DEFINE(FASTFLOAT_VISUAL_STUDIO);
+#endif
+#ifdef FASTFLOAT_IS_BIG_ENDIAN
+    #if FASTFLOAT_IS_BIG_ENDIAN
+      printf("big endian\n");
+    #else
+      printf("little endian\n");
+    #endif
+#endif
+#ifdef FASTFLOAT_32BIT
+    SHOW_DEFINE(FASTFLOAT_32BIT);
+#endif
+#ifdef FASTFLOAT_64BIT
+    SHOW_DEFINE(FASTFLOAT_64BIT);
+#endif
+#ifdef FLT_EVAL_METHOD
+    SHOW_DEFINE(FLT_EVAL_METHOD);
+#endif
+#ifdef _WIN32
+    SHOW_DEFINE(_WIN32);
+#endif
+#ifdef _WIN64
+    SHOW_DEFINE(_WIN64);
+#endif
+    std::cout << "fegetround() = " << round_name(fegetround()) << std::endl;
+    std::cout << std::endl;
+
+}
+
 
 TEST_CASE("rounds_to_nearest") {
   //
@@ -81,23 +134,6 @@ TEST_CASE("rounds_to_nearest") {
   CHECK(fegetround() == FE_TONEAREST);
   CHECK(fast_float::detail::rounds_to_nearest() == true);
 }
-
-const char * round_name(int d) {
-  switch(d) {
-    case FE_UPWARD:
-      return "FE_UPWARD";
-    case FE_DOWNWARD:
-      return "FE_DOWNWARD";
-    case FE_TOWARDZERO:
-      return "FE_TOWARDZERO";
-    case FE_TONEAREST:
-      return "FE_TONEAREST";
-    default:
-      return "UNKNOWN";
-  }
-
-}
-
 
 TEST_CASE("parse_zero") {
   //
@@ -145,6 +181,15 @@ TEST_CASE("parse_zero") {
   std::cout << "double as uint64_t is " << float64_parsed << std::endl;
   CHECK(float64_parsed == 0);
 }
+
+// C++ 17 because it is otherwise annoying to browse all files in a directory.
+// We also only run these tests on little endian systems.
+#if (FASTFLOAT_CPLUSPLUS >= 201703L) && (FASTFLOAT_IS_BIG_ENDIAN == 0) && !defined(FASTFLOAT_ODDPLATFORM)
+
+#include <iostream>
+#include <filesystem>
+#include <charconv>
+
 
 
 // return true on success

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -10,6 +10,7 @@
 #include <limits>
 #include <string>
 #include <system_error>
+#include <cfenv>
 
 #ifndef SUPPLEMENTAL_TEST_DATA_DIR
 #define SUPPLEMENTAL_TEST_DATA_DIR "data/"
@@ -42,6 +43,11 @@
 #define FASTFLOAT_ODDPLATFORM 1
 #endif
 
+
+#define iHexAndDec(v) std::hex << "0x" << (v) << " (" << std::dec << (v) << ")"
+#define fHexAndDec(v) std::hexfloat << (v) << " (" << std::defaultfloat << (v) << ")"
+
+
 // C++ 17 because it is otherwise annoying to browse all files in a directory.
 // We also only run these tests on little endian systems.
 #if (FASTFLOAT_CPLUSPLUS >= 201703L) && (FASTFLOAT_IS_BIG_ENDIAN == 0) && !defined(FASTFLOAT_ODDPLATFORM)
@@ -50,59 +56,111 @@
 #include <filesystem>
 #include <charconv>
 
+TEST_CASE("rounds_to_nearest") {
+  //
+  // If this function fails, we may be left in a non-standard rounding state.
+  //
+  static volatile float fmin = std::numeric_limits<float>::min();
+  fesetround(FE_UPWARD);
+  std::cout << "FE_UPWARD: fmin + 1.0f = " << iHexAndDec(fmin + 1.0f) << " 1.0f - fmin = " << iHexAndDec(1.0f - fmin) << std::endl;
+  CHECK(fegetround() == FE_UPWARD);
+  CHECK(fast_float::detail::rounds_to_nearest() == false);
+
+  fesetround(FE_DOWNWARD);
+  std::cout << "FE_DOWNWARD: fmin + 1.0f = " << iHexAndDec(fmin + 1.0f) << " 1.0f - fmin = " << iHexAndDec(1.0f - fmin) << std::endl;
+  CHECK(fegetround() == FE_DOWNWARD);
+  CHECK(fast_float::detail::rounds_to_nearest() == false);
+
+  fesetround(FE_TOWARDZERO);
+  std::cout << "FE_TOWARDZERO: fmin + 1.0f = " << iHexAndDec(fmin + 1.0f) << " 1.0f - fmin = " << iHexAndDec(1.0f - fmin) << std::endl;
+  CHECK(fegetround() == FE_TOWARDZERO);
+  CHECK(fast_float::detail::rounds_to_nearest() == false);
+
+  fesetround(FE_TONEAREST);
+  std::cout << "FE_TONEAREST: fmin + 1.0f = " << iHexAndDec(fmin + 1.0f) << " 1.0f - fmin = " << iHexAndDec(1.0f - fmin) << std::endl;
+  CHECK(fegetround() == FE_TONEAREST);
+  CHECK(fast_float::detail::rounds_to_nearest() == true);
+}
+
+const char * round_name(int d) {
+  switch(d) {
+    case FE_UPWARD:
+      return "FE_UPWARD";
+    case FE_DOWNWARD:
+      return "FE_DOWNWARD";
+    case FE_TOWARDZERO:
+      return "FE_TOWARDZERO";
+    case FE_TONEAREST:
+      return "FE_TONEAREST";
+    default:
+      return "UNKNOWN";
+  }
+
+}
+
 // return true on success
 bool check_file(std::string file_name) {
   std::cout << "Checking " << file_name << std::endl;
-  size_t number{0};
-  std::fstream newfile(file_name, std::ios::in);
-  if (newfile.is_open()) {
-    std::string str;
-    while (std::getline(newfile, str)) {
-      if (str.size() > 0) {
-        // Read 32-bit hex
-        uint32_t float32;
-        auto r32 = std::from_chars(str.data() + 5, str.data() + str.size(),
+  // We check all rounding directions, for each file.
+  std::vector<int> directions = {FE_UPWARD, FE_DOWNWARD, FE_TOWARDZERO, FE_TONEAREST};
+  for (int d : directions) {
+    std::cout << "fesetround to " << round_name(d) << std::endl;
+    fesetround(d);
+    size_t number{0};
+    std::fstream newfile(file_name, std::ios::in);
+    if (newfile.is_open()) {
+      std::string str;
+      while (std::getline(newfile, str)) {
+        if (str.size() > 0) {
+          // Read 32-bit hex
+          uint32_t float32;
+          auto r32 = std::from_chars(str.data() + 5, str.data() + str.size(),
                                    float32, 16);
-        if(r32.ec != std::errc()) { std::cerr << "32-bit parsing failure\n"; return false; }
-        // Read 64-bit hex
-        uint64_t float64;
-        auto r64 = std::from_chars(str.data() + 14, str.data() + str.size(),
+          if(r32.ec != std::errc()) { std::cerr << "32-bit parsing failure\n"; return false; }
+          // Read 64-bit hex
+          uint64_t float64;
+          auto r64 = std::from_chars(str.data() + 14, str.data() + str.size(),
                                    float64, 16);
-        if(r64.ec != std::errc()) { std::cerr << "64-bit parsing failure\n"; return false; }
-        // The string to parse:
-        const char *number_string = str.data() + 31;
-        const char *end_of_string = str.data() + str.size();
-        // Parse as 32-bit float
-        float parsed_32;
-        auto fast_float_r32 = fast_float::from_chars(number_string, end_of_string, parsed_32);
-        if(fast_float_r32.ec != std::errc()) { std::cerr << "parsing failure\n"; return false; }
-        // Parse as 64-bit float
-        double parsed_64;
-        auto fast_float_r64 = fast_float::from_chars(number_string, end_of_string, parsed_64);
-        if(fast_float_r64.ec != std::errc()) { std::cerr << "parsing failure\n"; return false; }
-        // Convert the floats to unsigned ints.
-        uint32_t float32_parsed;
-        uint64_t float64_parsed;
-        ::memcpy(&float32_parsed, &parsed_32, sizeof(parsed_32));
-        ::memcpy(&float64_parsed, &parsed_64, sizeof(parsed_64));
-        // Compare with expected results
-        if (float32_parsed != float32) {
-          std::cout << "bad 32 " << str << std::endl;
-          return false;
+          if(r64.ec != std::errc()) { std::cerr << "64-bit parsing failure\n"; return false; }
+          // The string to parse:
+          const char *number_string = str.data() + 31;
+          const char *end_of_string = str.data() + str.size();
+          // Parse as 32-bit float
+          float parsed_32;
+          auto fast_float_r32 = fast_float::from_chars(number_string, end_of_string, parsed_32);
+          if(fast_float_r32.ec != std::errc()) { std::cerr << "parsing failure\n"; return false; }
+          // Parse as 64-bit float
+          double parsed_64;
+          auto fast_float_r64 = fast_float::from_chars(number_string, end_of_string, parsed_64);
+          if(fast_float_r64.ec != std::errc()) { std::cerr << "parsing failure\n"; return false; }
+          // Convert the floats to unsigned ints.
+          uint32_t float32_parsed;
+          uint64_t float64_parsed;
+          ::memcpy(&float32_parsed, &parsed_32, sizeof(parsed_32));
+          ::memcpy(&float64_parsed, &parsed_64, sizeof(parsed_64));
+          // Compare with expected results
+          if (float32_parsed != float32) {
+            std::cout << "bad 32 " << str << std::endl;
+            fesetround(FE_TONEAREST);
+            return false;
+          }
+          if (float64_parsed != float64) {
+            std::cout << "bad 64 " << str << std::endl;
+            fesetround(FE_TONEAREST);
+            return false;
+          }
+          number++;
         }
-        if (float64_parsed != float64) {
-          std::cout << "bad 64 " << str << std::endl;
-          return false;
-        }
-        number++;
       }
+      std::cout << "checked " << std::defaultfloat << number << " values" << std::endl;
+      newfile.close(); // close the file object
+    } else {
+      std::cout << "Could not read  " << file_name << std::endl;
+      fesetround(FE_TONEAREST);
+      return false;
     }
-    std::cout << "checked " << std::defaultfloat << number << " values" << std::endl;
-    newfile.close(); // close the file object
-  } else {
-    std::cout << "Could not read  " << file_name << std::endl;
-    return false;
   }
+  fesetround(FE_TONEAREST);
   return true;
 }
 
@@ -124,9 +182,6 @@ TEST_CASE("leading_zeroes") {
   CHECK(fast_float::leading_zeroes(bit << 62) ==  1);
   CHECK(fast_float::leading_zeroes(bit << 63) ==  0);
 }
-
-#define iHexAndDec(v) std::hex << "0x" << (v) << " (" << std::dec << (v) << ")"
-#define fHexAndDec(v) std::hexfloat << (v) << " (" << std::defaultfloat << (v) << ")"
 
 void test_full_multiplication(uint64_t lhs, uint64_t rhs, uint64_t expected_lo, uint64_t expected_hi) {
   fast_float::value128 v;

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -104,27 +104,46 @@ TEST_CASE("parse_zero") {
   // If this function fails, we may be left in a non-standard rounding state.
   //
   const char * zero = "0";
+  uint64_t float64_parsed;
   double f = 0;
+  ::memcpy(&float64_parsed, &f, sizeof(f));
+  CHECK(float64_parsed == 0);
+
   fesetround(FE_UPWARD);
   auto r1 = fast_float::from_chars(zero, zero + 1, f);
   CHECK(r1.ec == std::errc());
   std::cout << "FE_UPWARD parsed zero as " << iHexAndDec(f) << std::endl;
   CHECK(f == 0);
+  ::memcpy(&float64_parsed, &f, sizeof(f));
+  std::cout << "double as uint64_t is " << float64_parsed << std::endl;
+  CHECK(float64_parsed == 0);
+
   fesetround(FE_TOWARDZERO);
   auto r2 = fast_float::from_chars(zero, zero + 1, f);
   CHECK(r2.ec == std::errc());
   std::cout << "FE_TOWARDZERO parsed zero as " << iHexAndDec(f) << std::endl;
   CHECK(f == 0);
+  ::memcpy(&float64_parsed, &f, sizeof(f));
+  std::cout << "double as uint64_t is " << float64_parsed << std::endl;
+  CHECK(float64_parsed == 0);
+
   fesetround(FE_DOWNWARD);
   auto r3 = fast_float::from_chars(zero, zero + 1, f);
   CHECK(r3.ec == std::errc());
   std::cout << "FE_DOWNWARD parsed zero as " << iHexAndDec(f) << std::endl;
   CHECK(f == 0);
+  ::memcpy(&float64_parsed, &f, sizeof(f));
+  std::cout << "double as uint64_t is " << float64_parsed << std::endl;
+  CHECK(float64_parsed == 0);
+
   fesetround(FE_TONEAREST);
   auto r4 = fast_float::from_chars(zero, zero + 1, f);
   CHECK(r4.ec == std::errc());
   std::cout << "FE_TONEAREST parsed zero as " << iHexAndDec(f) << std::endl;
   CHECK(f == 0);
+  ::memcpy(&float64_parsed, &f, sizeof(f));
+  std::cout << "double as uint64_t is " << float64_parsed << std::endl;
+  CHECK(float64_parsed == 0);
 }
 
 
@@ -171,14 +190,16 @@ bool check_file(std::string file_name) {
           // Compare with expected results
           if (float32_parsed != float32) {
             std::cout << "bad 32 " << str << std::endl;
-            std::cout << "parsed = " << iHexAndDec(float32_parsed) << ", expectd = " << iHexAndDec(float32) << std::endl;
+            std::cout << "parsed as " << iHexAndDec(parsed_32) << std::endl;
+            std::cout << "as  raw uint32_t, parsed = " << float32_parsed << ", expected = " << float32 << std::endl;
             std::cout << "fesetround: " << round_name(d) << std::endl;
             fesetround(FE_TONEAREST);
             return false;
           }
           if (float64_parsed != float64) {
             std::cout << "bad 64 " << str << std::endl;
-            std::cout << "parsed = " << iHexAndDec(float64_parsed) << ", expectd = " << iHexAndDec(float64) << std::endl;
+            std::cout << "parsed as " << iHexAndDec(parsed_64) << std::endl;
+            std::cout << "as raw uint64_t, parsed = " << float64_parsed << ", expected = " << float64 << std::endl;
             std::cout << "fesetround: " << round_name(d) << std::endl;
             fesetround(FE_TONEAREST);
             return false;


### PR DESCRIPTION
As remarked by @jakubjelinek, we cannot unconditionally use the conventional Clinger's fast path because it assumes that the rounding mode is set to 'nearest' (which is the universal default). Now, nothing stops a user from changing the rounding mode, but we need our code to produce the same result (rounding to nearest) irrespective of the system's rounding mode.

Checking that `fegetround() == FE_TONEAREST` is too expensive on some systems.

A better solution was proposed by  @mwalcott3  and involves doing an addition, a subtraction and a comparison to verify that the rounding mode is set to nearest. Because parsing a float might already involve hundreds of instructions, this check is relatively cheap. The resulting branch is also invariably well predicted.

This allows us to bring back the Clinger's fast path when the test is ok (which is always in practice). When it does not apply, we can still use another 'Clinger-like' fast path (based on a proposal by @jakubjelinek).

The result is an increased performance when the Clinger's fast path applies and the 'Clinger-like' fast path would not.

It can cause a slightly performance regression in cases (such as 'canada.txt') when the fast path is not beneficial because we now have a more expensive check, though this may depend on the compiler. There might be ways to micro-optimize this better than what the current PR proposes.

## Ice Lake processor, GCC 11:

Current code:
```
-f data/canada.txt
fastfloat                               :   933.44 MB/s (+/- 1.4 %)    53.64 Mfloat/s  
-f data/canada_short.txt
fastfloat                               :   374.20 MB/s (+/- 1.2 %)    69.53 Mfloat/s  
-f data/mesh.txt
fastfloat                               :   676.27 MB/s (+/- 1.7 %)    92.13 Mfloat/s  
-m uniform
fastfloat                               :  1219.35 MB/s (+/- 2.3 %)    58.12 Mfloat/s  
-m uniform -c
fastfloat                               :   951.23 MB/s (+/- 2.4 %)    54.59 Mfloat/s  
-m simple_uniform32
fastfloat                               :  1225.69 MB/s (+/- 3.0 %)    58.42 Mfloat/s  
-m simple_uniform32 -c
fastfloat                               :   944.60 MB/s (+/- 2.1 %)    54.22 Mfloat/s  
-m simple_int32
fastfloat                               :   771.49 MB/s (+/- 3.1 %)    83.05 Mfloat/s 
```

This PR:
```
-f data/canada.txt
fastfloat                               :   953.92 MB/s (+/- 12.2 %)    54.82 Mfloat/s  
-f data/canada_short.txt
fastfloat                               :   584.63 MB/s (+/- 7.2 %)   108.62 Mfloat/s  
-f data/mesh.txt
fastfloat                               :   809.69 MB/s (+/- 3.6 %)   110.30 Mfloat/s  
-m uniform
fastfloat                               :  1204.92 MB/s (+/- 2.1 %)    57.43 Mfloat/s  
-m uniform -c
fastfloat                               :  1025.67 MB/s (+/- 2.2 %)    58.88 Mfloat/s  
-m simple_uniform32
fastfloat                               :  1222.26 MB/s (+/- 2.0 %)    58.26 Mfloat/s  
-m simple_uniform32 -c
fastfloat                               :  1019.27 MB/s (+/- 5.3 %)    58.49 Mfloat/s  
-m simple_int32
fastfloat                               :   772.84 MB/s (+/- 15.4 %)    83.20 Mfloat/s  
```

Using `fegetround() == FE_TONEAREST` to guard Clinger's (slow):

```
-f data/canada.txt
fastfloat                               :   778.68 MB/s (+/- 1.8 %)    44.75 Mfloat/s  
-f data/canada_short.txt
fastfloat                               :   482.55 MB/s (+/- 1.3 %)    89.66 Mfloat/s  
-f data/mesh.txt
fastfloat                               :   631.72 MB/s (+/- 2.0 %)    86.06 Mfloat/s  
-m uniform
fastfloat                               :   915.72 MB/s (+/- 5.3 %)    43.65 Mfloat/s  
-m uniform -c
fastfloat                               :   992.28 MB/s (+/- 3.0 %)    56.94 Mfloat/s  
-m simple_uniform32
fastfloat                               :   915.51 MB/s (+/- 1.1 %)    43.64 Mfloat/s  
-m simple_uniform32 -c
fastfloat                               :   992.24 MB/s (+/- 3.2 %)    56.95 Mfloat/s  
-m simple_int32
fastfloat                               :   693.57 MB/s (+/- 3.6 %)    74.67 Mfloat/s  
```

## Apple M2 processor, LLVM 14:

current code:

```
-f data/canada.txt
fastfloat                               :  1387.19 MB/s (+/- 0.7 %)    79.72 Mfloat/s      15.90 i/B   290.11 i/f (+/- 0.0 %)      2.41 c/B    43.96 c/f (+/- 0.5 %)      6.60 i/c      3.50 GHz
-f data/canada_short.txt
fastfloat                               :   615.83 MB/s (+/- 1.1 %)   114.42 Mfloat/s      37.59 i/B   212.15 i/f (+/- 0.0 %)      5.28 c/B    29.79 c/f (+/- 0.3 %)      7.12 i/c      3.41 GHz
-f data/mesh.txt
fastfloat                               :   878.58 MB/s (+/- 1.9 %)   119.69 Mfloat/s      24.01 i/B   184.79 i/f (+/- 0.0 %)      3.69 c/B    28.40 c/f (+/- 1.8 %)      6.51 i/c      3.40 GHz
-m uniform
fastfloat                               :  1894.65 MB/s (+/- 0.7 %)    90.30 Mfloat/s      12.59 i/B   277.04 i/f (+/- 0.0 %)      1.72 c/B    37.74 c/f (+/- 0.2 %)      7.34 i/c      3.41 GHz
-m uniform -c
fastfloat                               :  1404.54 MB/s (+/- 0.6 %)    80.61 Mfloat/s      13.08 i/B   239.04 i/f (+/- 0.0 %)      2.31 c/B    42.28 c/f (+/- 0.2 %)      5.65 i/c      3.41 GHz
-m simple_uniform32
fastfloat                               :  1894.15 MB/s (+/- 0.4 %)    90.28 Mfloat/s      12.59 i/B   277.04 i/f (+/- 0.0 %)      1.72 c/B    37.75 c/f (+/- 0.2 %)      7.34 i/c      3.41 GHz
-m simple_uniform32 -c
fastfloat                               :  1414.14 MB/s (+/- 1.4 %)    81.16 Mfloat/s      13.08 i/B   239.01 i/f (+/- 0.0 %)      2.30 c/B    42.00 c/f (+/- 1.0 %)      5.69 i/c      3.41 GHz
-m simple_int32
fastfloat                               :   998.10 MB/s (+/- 0.8 %)   107.46 Mfloat/s      20.17 i/B   196.39 i/f (+/- 0.0 %)      3.26 c/B    31.72 c/f (+/- 0.2 %)      6.19 i/c      3.41 GHz
```

this PR:
```
-f data/canada.txt
fastfloat                               :  1312.35 MB/s (+/- 3.7 %)    75.42 Mfloat/s      16.71 i/B   304.92 i/f (+/- 0.0 %)      2.52 c/B    46.06 c/f (+/- 1.0 %)      6.62 i/c      3.47 GHz
-f data/canada_short.txt
fastfloat                               :   764.14 MB/s (+/- 3.6 %)   141.98 Mfloat/s      30.64 i/B   172.94 i/f (+/- 0.0 %)      4.34 c/B    24.48 c/f (+/- 0.4 %)      7.07 i/c      3.48 GHz
-f data/mesh.txt
fastfloat                               :   964.26 MB/s (+/- 1.3 %)   131.36 Mfloat/s      22.32 i/B   171.83 i/f (+/- 0.0 %)      3.34 c/B    25.72 c/f (+/- 1.8 %)      6.68 i/c      3.38 GHz
-m uniform
fastfloat                               :  1784.08 MB/s (+/- 0.8 %)    85.03 Mfloat/s      13.50 i/B   297.04 i/f (+/- 0.0 %)      1.82 c/B    40.08 c/f (+/- 0.1 %)      7.41 i/c      3.41 GHz
-m uniform -c
fastfloat                               :  1409.95 MB/s (+/- 1.2 %)    80.93 Mfloat/s      12.03 i/B   219.84 i/f (+/- 0.0 %)      2.31 c/B    42.11 c/f (+/- 0.9 %)      5.22 i/c      3.41 GHz
-m simple_uniform32
fastfloat                               :  1783.64 MB/s (+/- 0.4 %)    85.01 Mfloat/s      13.50 i/B   297.04 i/f (+/- 0.0 %)      1.82 c/B    40.09 c/f (+/- 0.2 %)      7.41 i/c      3.41 GHz
-m simple_uniform32 -c
fastfloat                               :  1409.90 MB/s (+/- 1.2 %)    80.91 Mfloat/s      12.03 i/B   219.90 i/f (+/- 0.0 %)      2.31 c/B    42.13 c/f (+/- 0.8 %)      5.22 i/c      3.41 GHz
-m simple_int32
fastfloat                               :   969.15 MB/s (+/- 0.8 %)   104.31 Mfloat/s      21.09 i/B   205.43 i/f (+/- 0.0 %)      3.35 c/B    32.67 c/f (+/- 0.2 %)      6.29 i/c      3.41 GHz
```



cc @jakubjelinek  
credit to @mwalcott3 