### PR TITLE
Proof of concept: constexpr from_chars

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -12,9 +12,11 @@ namespace fast_float {
 
 // Next function can be micro-optimized, but compilers are entirely
 // able to optimize it well.
-fastfloat_really_inline bool is_integer(char c)  noexcept  { return c >= '0' && c <= '9'; }
+fastfloat_really_inline constexpr bool is_integer(char c) noexcept {
+  return c >= '0' && c <= '9';
+}
 
-fastfloat_really_inline uint64_t byteswap(uint64_t val) {
+fastfloat_really_inline constexpr uint64_t byteswap(uint64_t val) {
   return (val & 0xFF00000000000000) >> 56
     | (val & 0x00FF000000000000) >> 40
     | (val & 0x0000FF0000000000) >> 24
@@ -84,8 +86,9 @@ struct parsed_number_string {
 
 // Assuming that you use no more than 19 digits, this will
 // parse an ASCII string.
-fastfloat_really_inline
-parsed_number_string parse_number_string(const char *p, const char *pend, parse_options options) noexcept {
+fastfloat_really_inline constexpr parsed_number_string
+parse_number_string(const char *p, const char *pend,
+                    parse_options options) noexcept {
   const chars_format fmt = options.format;
   const char decimal_point = options.decimal_point;
 

--- a/include/fast_float/decimal_to_binary.h
+++ b/include/fast_float/decimal_to_binary.h
@@ -17,8 +17,8 @@ namespace fast_float {
 // low part corresponding to the least significant bits.
 //
 template <int bit_precision>
-fastfloat_really_inline
-value128 compute_product_approximation(int64_t q, uint64_t w) {
+fastfloat_really_inline constexpr value128
+compute_product_approximation(int64_t q, uint64_t w) {
   const int index = 2 * int(q - powers::smallest_power_of_five);
   // For small values of q, e.g., q in [0,27], the answer is always exact because
   // The line value128 firstproduct = full_multiplication(w, power_of_five_128[index]);
@@ -90,8 +90,8 @@ adjusted_mantissa compute_error(int64_t q, uint64_t w)  noexcept  {
 // return an adjusted_mantissa with a negative power of 2: the caller should recompute
 // in such cases.
 template <typename binary>
-fastfloat_really_inline
-adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
+fastfloat_really_inline constexpr adjusted_mantissa
+compute_float(int64_t q, uint64_t w) noexcept {
   adjusted_mantissa answer;
   if ((w == 0) || (q < binary::smallest_power_of_ten())) {
     answer.power2 = 0;

--- a/include/fast_float/fast_float.h
+++ b/include/fast_float/fast_float.h
@@ -48,15 +48,17 @@ struct parse_options {
  * The default is  `fast_float::chars_format::general` which allows both `fixed` and `scientific`.
  */
 template<typename T>
-from_chars_result from_chars(const char *first, const char *last,
-                             T &value, chars_format fmt = chars_format::general)  noexcept;
+constexpr from_chars_result
+from_chars(const char *first, const char *last, T &value,
+           chars_format fmt = chars_format::general) noexcept;
 
 /**
  * Like from_chars, but accepts an `options` argument to govern number parsing.
  */
 template<typename T>
-from_chars_result from_chars_advanced(const char *first, const char *last,
-                                      T &value, parse_options options)  noexcept;
+constexpr from_chars_result from_chars_advanced(const char *first,
+                                                const char *last, T &value,
+                                                parse_options options) noexcept;
 
 } // namespace fast_float
 #include "parse_number.h"

--- a/include/fast_float/fast_table.h
+++ b/include/fast_float/fast_table.h
@@ -40,7 +40,7 @@ static const uint64_t power_of_five_128[number_of_entries];
 };
 
 template <class unused>
-const uint64_t powers_template<unused>::power_of_five_128[number_of_entries] = {
+constexpr uint64_t powers_template<unused>::power_of_five_128[number_of_entries] = {
         0xeef453d6923bd65a,0x113faa2906a13b3f,
         0x9558b4661b6565f8,0x4ac7ca59a424c507,
         0xbaaee17fa23ebf76,0x5d79bcf00d2df649,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,8 @@ target_compile_features(basictest PRIVATE cxx_std_17)
 fast_float_add_cpp_test(long_test)
 fast_float_add_cpp_test(powersoffive_hardround)
 fast_float_add_cpp_test(string_test)
+fast_float_add_cpp_test(constexpr)
+target_compile_features(constexpr PRIVATE cxx_std_20)
 
 
 

--- a/tests/constexpr.cpp
+++ b/tests/constexpr.cpp
@@ -1,0 +1,39 @@
+#include "fast_float/fast_float.h"
+
+constexpr double zero = [] {
+  double ret = 0;
+
+  const char *str = "0";
+
+  fast_float::from_chars(str, str + 1, ret);
+
+  return ret;
+}();
+
+static_assert(zero == 0.);
+
+constexpr double pi = [] {
+  double ret = 0;
+
+  const char *str = "3.1415";
+
+  fast_float::from_chars(str, str + 6, ret);
+
+  return ret;
+}();
+
+static_assert(pi == 3.1415);
+
+constexpr double googol = [] {
+  double ret = 0;
+
+  const char *str = "1e100";
+
+  fast_float::from_chars(str, str + 5, ret);
+
+  return ret;
+}();
+
+static_assert(googol == 1e100);
+
+int main() { return 0; }


### PR DESCRIPTION
Hi,

On the weekend I played around with trying to make from_chars constexpr, at least when compiled in C++20.

Would such efforts be welcome?

This looks surprisingly straightforward in C++20. The major obstacles are:
1. Work around the rounding mode detection, which can't work in constexpr. This can be managed with `std::is_constant_evaluated()`, either by unconditionally going to the slow path in constexpr, or relying that compilers implement rounding to nearest in constexpr. I implemented the latter, but in hindsight I should probably have implemented the former, just to be safe.
2. `memcpy`. This can be replaced with `std::bit_cast` in C++20.

I have ideas to work around both of these before C++20, but that's a little bit more involved.