### PR TITLE
Simplify to_float

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -443,20 +443,11 @@ template <> inline constexpr binary_format<double>::equiv_uint
 
 template<typename T>
 fastfloat_really_inline void to_float(bool negative, adjusted_mantissa am, T &value) {
-  uint64_t word = am.mantissa;
-  word |= uint64_t(am.power2) << binary_format<T>::mantissa_explicit_bits();
-  word = negative
-  ? word | (uint64_t(1) << binary_format<T>::sign_index()) : word;
-#if FASTFLOAT_IS_BIG_ENDIAN == 1
-   if (std::is_same<T, float>::value) {
-     ::memcpy(&value, (char *)&word + 4, sizeof(T)); // extract value at offset 4-7 if float on big-endian
-   } else {
-     ::memcpy(&value, &word, sizeof(T));
-   }
-#else
-   // For little-endian systems:
-   ::memcpy(&value, &word, sizeof(T));
-#endif
+  using uint = typename binary_format<T>::equiv_uint;
+  uint word = (uint)am.mantissa;
+  word |= uint(am.power2) << binary_format<T>::mantissa_explicit_bits();
+  word |= uint(negative) << binary_format<T>::sign_index();
+  ::memcpy(&value, &word, sizeof(T));
 }
 
 #if FASTFLOAT_SKIP_WHITE_SPACE // disabled by default


### PR DESCRIPTION
* Use right-sized uint type for bit fiddling
  * This removes the need to special casing on endianness
* Replace ternary with just shifting the sign at the right place
  * This seems to improve codegen (less instructions, no cmov)

Codegen demonstration:

gcc 12: https://godbolt.org/z/ceYK4crde
clang 15: https://godbolt.org/z/WTcqn8xGv
MSVC 19.14: https://godbolt.org/z/P3d8dv9Eq