### PR TITLE
Added missing FASTFLOAT_ALLOWS_LEADING_PLUS ifdef check in parse_infnan

### DIFF
--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -29,6 +29,11 @@ from_chars_result parse_infnan(const char *first, const char *last, T &value)  n
       minusSign = true;
       ++first;
   }
+#if FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
+  if (*first == '+') {
+      ++first;
+  }
+#endif
   if (last - first >= 3) {
     if (fastfloat_strncasecmp(first, "nan", 3)) {
       answer.ptr = (first += 3);


### PR DESCRIPTION
This issue was detected via https://github.com/redis/redis/actions/runs/4349106283/jobs/7598380101 , specifically the part of `zadd ztmp +inf x`
The error is related to the +inf parsing. After checking parse_infnan we can indeed confirm that the '+' sign is not being checked and the str position is updated accordingly. This PR addresses it. 