### PR TITLE
Fix warnings with -Wundef

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -116,7 +116,7 @@ parsed_number_string parse_number_string(const char *p, const char *pend, parse_
   answer.valid = false;
   answer.too_many_digits = false;
   answer.negative = (*p == '-');
-#if FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
+#ifdef FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
   if ((*p == '-') || (*p == '+')) {
 #else
   if (*p == '-') { // C++17 20.19.3.(7.1) explicitly forbids '+' sign here

--- a/include/fast_float/constexpr_feature_detect.h
+++ b/include/fast_float/constexpr_feature_detect.h
@@ -14,13 +14,13 @@
 #define FASTFLOAT_CONSTEXPR14
 #endif
 
-#if __cpp_lib_bit_cast >= 201806L
+#if defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L
 #define FASTFLOAT_HAS_BIT_CAST 1
 #else
 #define FASTFLOAT_HAS_BIT_CAST 0
 #endif
 
-#if __cpp_lib_is_constant_evaluated >= 201811L
+#if defined(__cpp_lib_is_constant_evaluated) && __cpp_lib_is_constant_evaluated >= 201811L
 #define FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 1
 #else
 #define FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 0

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -481,7 +481,7 @@ void to_float(bool negative, adjusted_mantissa am, T &value) {
 #endif
 }
 
-#if FASTFLOAT_SKIP_WHITE_SPACE // disabled by default
+#ifdef FASTFLOAT_SKIP_WHITE_SPACE // disabled by default
 template <typename = void>
 struct space_lut {
   static constexpr bool value[] = {

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -30,7 +30,7 @@ parse_infnan(const char *first, const char *last, T &value)  noexcept  {
       minusSign = true;
       ++first;
   }
-#if FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
+#ifdef FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
   if (*first == '+') {
       ++first;
   }
@@ -109,7 +109,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   //
   // Note: This may fail to be accurate if fast-math has been
   // enabled, as rounding conventions may not apply.
-  #if FASTFLOAT_VISUAL_STUDIO
+  #ifdef FASTFLOAT_VISUAL_STUDIO
   #   pragma warning(push)
   //  todo: is there a VS warning?
   //  see https://stackoverflow.com/questions/46079446/is-there-a-warning-for-floating-point-equality-checking-in-visual-studio-2013
@@ -121,7 +121,7 @@ fastfloat_really_inline bool rounds_to_nearest() noexcept {
   #   pragma GCC diagnostic ignored "-Wfloat-equal"
   #endif
   return (fmini + 1.0f == 1.0f - fmini);
-  #if FASTFLOAT_VISUAL_STUDIO
+  #ifdef FASTFLOAT_VISUAL_STUDIO
   #   pragma warning(pop)
   #elif defined(__clang__)
   #   pragma clang diagnostic pop
@@ -148,7 +148,7 @@ from_chars_result from_chars_advanced(const char *first, const char *last,
 
 
   from_chars_result answer;
-#if FASTFLOAT_SKIP_WHITE_SPACE  // disabled by default
+#ifdef FASTFLOAT_SKIP_WHITE_SPACE  // disabled by default
   while ((first != last) && fast_float::is_space(uint8_t(*first))) {
     first++;
   }


### PR DESCRIPTION
- `FASTFLOAT_ALLOWS_LEADING_PLUS` and `FASTFLOAT_SKIP_WHITE_SPACE` are not defined by default, and compiling with `-Wundef` is emitting warnings like "FASTFLOAT_ALLOWS_LEADING_PLUS is not defined, evaluates to 0".
- Likewise for `FASTFLOAT_VISUAL_STUDIO`, change checks to use #ifdef for that like in other places.
- `__cpp_lib_bit_cast` and `__cpp_lib_is_constant_evaluated` are not defined pre-C++20, and are emitting a warning too.