### PR TITLE
Fix for broken VS Intellisense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,21 @@ build/*
 Testing/*
 .cache/
 compile_commands.json
+
+# Visual Studio
+.vs/
+Debug/
+Release/
+*.sln
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user
+*.psess
+*.vspx
+*.vsp
+*.diagsession
+*.hint
+
+# VS CMake
+/out/
+/CMakeSettings.json

--- a/include/fast_float/fast_float.h
+++ b/include/fast_float/fast_float.h
@@ -1,38 +1,10 @@
+
 #ifndef FASTFLOAT_FAST_FLOAT_H
 #define FASTFLOAT_FAST_FLOAT_H
 
-#include <system_error>
-
-#include "constexpr_feature_detect.h"
+#include "float_common.h"
 
 namespace fast_float {
-enum chars_format {
-    scientific = 1<<0,
-    fixed = 1<<2,
-    hex = 1<<3,
-    general = fixed | scientific
-};
-
-template <typename UC>
-struct from_chars_result_t {
-  UC const * ptr;
-  std::errc ec;
-};
-using from_chars_result = from_chars_result_t<char>;
-
-template <typename UC>
-struct parse_options_t {
-  constexpr explicit parse_options_t(chars_format fmt = chars_format::general,
-                         UC dot = UC('.'))
-    : format(fmt), decimal_point(dot) {}
-
-  /** Which number formats are accepted */
-  chars_format format;
-  /** The character used as decimal point */
-  UC decimal_point;
-};
-using parse_options = parse_options_t<char>;
-
 /**
  * This function parses the character sequence [first,last) for a number. It parses floating-point numbers expecting
  * a locale-indepent format equivalent to what is used by std::strtod in the default ("C") locale.

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -6,6 +6,40 @@
 #include <cassert>
 #include <cstring>
 #include <type_traits>
+#include <system_error>
+
+#include "constexpr_feature_detect.h"
+
+namespace fast_float {
+
+enum chars_format {
+  scientific = 1 << 0,
+  fixed = 1 << 2,
+  hex = 1 << 3,
+  general = fixed | scientific
+};
+
+template <typename UC>
+struct from_chars_result_t {
+  UC const* ptr;
+  std::errc ec;
+};
+using from_chars_result = from_chars_result_t<char>;
+
+template <typename UC>
+struct parse_options_t {
+  constexpr explicit parse_options_t(chars_format fmt = chars_format::general,
+    UC dot = UC('.'))
+    : format(fmt), decimal_point(dot) {}
+
+  /** Which number formats are accepted */
+  chars_format format;
+  /** The character used as decimal point */
+  UC decimal_point;
+};
+using parse_options = parse_options_t<char>;
+
+}
 
 #if FASTFLOAT_HAS_BIT_CAST
 #include <bit>

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -4,6 +4,7 @@
 #include "ascii_number.h"
 #include "decimal_to_binary.h"
 #include "digit_comparison.h"
+#include "float_common.h"
 
 #include <cmath>
 #include <cstring>

--- a/script/amalgamate.py
+++ b/script/amalgamate.py
@@ -31,9 +31,8 @@ for filename in ['LICENSE-MIT', 'LICENSE-APACHE']:
   processed_files[filename] = text
 
 # code
-for filename in [ 'constexpr_feature_detect.h', 'fast_float.h', 'float_common.h', 'ascii_number.h',
-                  'fast_table.h', 'decimal_to_binary.h', 'bigint.h',
-                  'ascii_number.h', 'digit_comparison.h', 'parse_number.h']:
+for filename in [ 'constexpr_feature_detect.h', 'float_common.h', 'fast_float.h', 'ascii_number.h',
+                  'fast_table.h', 'decimal_to_binary.h', 'bigint.h', 'digit_comparison.h', 'parse_number.h']:
   with open('include/fast_float/' + filename, encoding='utf8') as f:
     text = ''
     for line in f:
@@ -76,11 +75,10 @@ text = ''.join([
   processed_files['AUTHORS'], processed_files['CONTRIBUTORS'],
   *license_content(args.license),
   processed_files['constexpr_feature_detect.h'],
-  processed_files['fast_float.h'], processed_files['float_common.h'],
+  processed_files['float_common.h'], processed_files['fast_float.h'],
   processed_files['ascii_number.h'], processed_files['fast_table.h'],
   processed_files['decimal_to_binary.h'], processed_files['bigint.h'],
-  processed_files['ascii_number.h'], processed_files['digit_comparison.h'],
-  processed_files['parse_number.h']])
+  processed_files['digit_comparison.h'], processed_files['parse_number.h']])
 
 if args.output:
   with open(args.output, 'wt', encoding='utf8') as f:


### PR DESCRIPTION
Intellisense is broken with this library, making it almost impossible to work on in Visual Studio. VS2017 to VS2022 are all affected.

![image](https://user-images.githubusercontent.com/34803055/236658617-9ed2af80-f585-4fc8-917b-879e062a5cfa.png)

This cause of this issue was reported 6 years ago: https://developercommunity.visualstudio.com/t/intellisense-breaks-for-header-files-if-not-includ/92374, but the VS team said they had no plans to fix it.

This PR applies a fix that has worked for me in past projects i.e. a file should include all definitions it uses.

"constexpr_feature_detect.h", <system_error>, and from_chars types (from_chars_result, parse_options etc.) should be included in every file to be seen by Intellisense (instead of just once in fast_float.h).