### PR TITLE
ARM NEON optimization (UTF-16 inputs)

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -91,21 +91,21 @@ FASTFLOAT_SIMD_DISABLE_WARNINGS
 FASTFLOAT_SIMD_RESTORE_WARNINGS
 }
 
-#elif defined(FASTFLOAT_ARM64)
+#elif defined(FASTFLOAT_NEON)
 
 
 fastfloat_really_inline
 uint64_t simd_read8_to_u64(const uint16x8_t data) {
 FASTFLOAT_SIMD_DISABLE_WARNINGS
   uint8x8_t utf8_packed = vmovn_u16(data);
-  vget_lane_u64(vreinterpret_u64_u8(utf8_packed), 0);
+  return vget_lane_u64(vreinterpret_u64_u8(utf8_packed), 0);
 FASTFLOAT_SIMD_RESTORE_WARNINGS
 }
 
 fastfloat_really_inline
 uint64_t simd_read8_to_u64(const char16_t* chars) {
 FASTFLOAT_SIMD_DISABLE_WARNINGS
-  return simd_read8_to_u64(vld1q_u16(reinterpret_cast<const uint16_t*>(values)));
+  return simd_read8_to_u64(vld1q_u16(reinterpret_cast<const uint16_t*>(chars)));
 FASTFLOAT_SIMD_RESTORE_WARNINGS
 }
 
@@ -191,9 +191,9 @@ FASTFLOAT_SIMD_DISABLE_WARNINGS
   }
   else return false;
 FASTFLOAT_SIMD_RESTORE_WARNINGS
-#elif defined(FASTFLOAT_ARM64)
+#elif defined(FASTFLOAT_NEON)
 FASTFLOAT_SIMD_DISABLE_WARNINGS
-  const uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t*>(chars))
+  const uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t*>(chars));
   
   // (x - '0') <= 9
   // http://0x80.pl/articles/simd-parsing-int-sequences.html

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -206,7 +206,9 @@ FASTFLOAT_SIMD_DISABLE_WARNINGS
   }
   else return false;
 FASTFLOAT_SIMD_RESTORE_WARNINGS
-
+#else
+  (void)chars; (void)i;
+  return false;
 #endif // FASTFLOAT_SSE2
 }
 
@@ -214,7 +216,7 @@ FASTFLOAT_SIMD_RESTORE_WARNINGS
 
 // dummy for compile
 template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>())>
-uint64_t simd_parse_if_eight_digits_unrolled(UC const*, uint64_t&) {
+bool simd_parse_if_eight_digits_unrolled(UC const*, uint64_t&) {
   return 0;
 }
 

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -13,6 +13,9 @@
 #include <emmintrin.h>
 #endif
 
+#ifdef FASTFLOAT_NEON
+#include <arm_neon.h>
+#endif
 
 namespace fast_float {
 
@@ -88,7 +91,25 @@ FASTFLOAT_SIMD_DISABLE_WARNINGS
 FASTFLOAT_SIMD_RESTORE_WARNINGS
 }
 
-#endif
+#elif defined(FASTFLOAT_ARM64)
+
+
+fastfloat_really_inline
+uint64_t simd_read8_to_u64(const uint16x8_t data) {
+FASTFLOAT_SIMD_DISABLE_WARNINGS
+  uint8x8_t utf8_packed = vmovn_u16(data);
+  vget_lane_u64(vreinterpret_u64_u8(utf8_packed), 0);
+FASTFLOAT_SIMD_RESTORE_WARNINGS
+}
+
+fastfloat_really_inline
+uint64_t simd_read8_to_u64(const char16_t* chars) {
+FASTFLOAT_SIMD_DISABLE_WARNINGS
+  return simd_read8_to_u64(vld1q_u16(reinterpret_cast<const uint16_t*>(values)));
+FASTFLOAT_SIMD_RESTORE_WARNINGS
+}
+
+#endif // FASTFLOAT_SSE2
 
 // dummy for compile
 template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>())>
@@ -170,10 +191,26 @@ FASTFLOAT_SIMD_DISABLE_WARNINGS
   }
   else return false;
 FASTFLOAT_SIMD_RESTORE_WARNINGS
-#endif
+#elif defined(FASTFLOAT_ARM64)
+FASTFLOAT_SIMD_DISABLE_WARNINGS
+  const uint16x8_t data = vld1q_u16(reinterpret_cast<const uint16_t*>(chars))
+  
+  // (x - '0') <= 9
+  // http://0x80.pl/articles/simd-parsing-int-sequences.html
+  const uint16x8_t t0 = vsubq_u16(data, vmovq_n_u16('0'));
+  const uint16x8_t mask = vcltq_u16(t0, vmovq_n_u16('9' - '0' + 1));
+
+  if (vminvq_u16(mask) == 0xFFFF) {
+    i = i * 100000000 + parse_eight_digits_unrolled(simd_read8_to_u64(data));
+    return true;
+  }
+  else return false;
+FASTFLOAT_SIMD_RESTORE_WARNINGS
+
+#endif // FASTFLOAT_SSE2
 }
 
-#endif
+#endif // FASTFLOAT_HAS_SIMD
 
 // dummy for compile
 template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>())>

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -121,7 +121,11 @@ using parse_options = parse_options_t<char>;
 #define FASTFLOAT_SSE2 1
 #endif
 
-#ifdef FASTFLOAT_SSE2
+#if defined(__aarch64__) || defined(_M_ARM64)
+#define FASTFLOAT_NEON 1
+#endif
+
+#if defined(FASTFLOAT_SSE2) || defined(FASTFLOAT_ARM64)
 #define FASTFLOAT_HAS_SIMD 1
 #endif
 


### PR DESCRIPTION
This is an obvious follow-up to the work done by @mayawarrier in https://github.com/fastfloat/fast_float/pull/198

I am getting a nice performance bump on the canada test (Apple M2, LLVM 14):


Before:
```
fastfloat                               :  2328.12 MB/s (+/- 1.3 %)    66.89 Mfloat/s       9.40 i/B   343.05 i/f (+/- 0.0 %)      1.44 c/B    52.42 c/f (+/- 0.7 %)      6.54 i/c      3.51 GHz
```

After:
```
fastfloat                               :  2617.00 MB/s (+/- 1.4 %)    75.20 Mfloat/s       8.60 i/B   313.66 i/f (+/- 0.0 %)      1.28 c/B    46.63 c/f (+/- 0.7 %)      6.73 i/c      3.51 GHz
```

Possibly, it could be further improved because NEON is far superior to SSE2, but it is already decent.