### PR TITLE
Fix broken msvc v140

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ Release/
 # VS CMake
 /out/
 /CMakeSettings.json
-/include/fast_float/fast_float_parser.h

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Release/
 # VS CMake
 /out/
 /CMakeSettings.json
+/include/fast_float/fast_float_parser.h

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -112,7 +112,8 @@ FASTFLOAT_SIMD_RESTORE_WARNINGS
 #endif // FASTFLOAT_SSE2
 
 // dummy for compile
-template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>())>
+//template <typename UC, FASTFLOAT_ENABLE_IF(!has_simd_opt<UC>())>
+template <typename UC>
 uint64_t simd_read8_to_u64(UC const*) {
   return 0;
 }


### PR DESCRIPTION
When using msvc v140 (Visual Studio 2015 Toolset), compilation fails.