### PR TITLE
float_common.h: fix possible misuse of comma operator

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -217,8 +217,8 @@ struct value128 {
   constexpr value128() : low(0), high(0) {}
 };
 
-/* Helper C++11 constexpr generic implementation of leading_zeroes */
-fastfloat_really_inline constexpr
+/* Helper C++14 constexpr generic implementation of leading_zeroes */
+fastfloat_really_inline FASTFLOAT_CONSTEXPR14
 int leading_zeroes_generic(uint64_t input_num, int last_bit = 0) {
     if(input_num & uint64_t(0xffffffff00000000)) { input_num >>= 32; last_bit |= 32; }
     if(input_num & uint64_t(        0xffff0000)) { input_num >>= 16; last_bit |= 16; }

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -220,15 +220,13 @@ struct value128 {
 /* Helper C++11 constexpr generic implementation of leading_zeroes */
 fastfloat_really_inline constexpr
 int leading_zeroes_generic(uint64_t input_num, int last_bit = 0) {
-  return (
-    ((input_num & uint64_t(0xffffffff00000000)) && (input_num >>= 32, last_bit |= 32)),
-    ((input_num & uint64_t(        0xffff0000)) && (input_num >>= 16, last_bit |= 16)),
-    ((input_num & uint64_t(            0xff00)) && (input_num >>=  8, last_bit |=  8)),
-    ((input_num & uint64_t(              0xf0)) && (input_num >>=  4, last_bit |=  4)),
-    ((input_num & uint64_t(               0xc)) && (input_num >>=  2, last_bit |=  2)),
-    ((input_num & uint64_t(               0x2)) && (input_num >>=  1, last_bit |=  1)),
-    63 - last_bit
-  );
+    if(input_num & uint64_t(0xffffffff00000000)) { input_num >>= 32; last_bit |= 32; }
+    if(input_num & uint64_t(        0xffff0000)) { input_num >>= 16; last_bit |= 16; }
+    if(input_num & uint64_t(            0xff00)) { input_num >>=  8; last_bit |=  8; }
+    if(input_num & uint64_t(              0xf0)) { input_num >>=  4; last_bit |=  4; }
+    if(input_num & uint64_t(               0xc)) { input_num >>=  2; last_bit |=  2; }
+    if(input_num & uint64_t(               0x2)) { input_num >>=  1; last_bit |=  1; }
+    return 63 - last_bit;
 }
 
 /* result might be undefined when input_num is zero */


### PR DESCRIPTION
Xcode 15 is showing warnings when including fast_float. See screenshot.
<img width="1144" alt="Capture d’écran 2023-06-12 à 21 03 12" src="https://github.com/fastfloat/fast_float/assets/839992/56802a66-3c3b-4c67-9998-3a0358577bec">

That warning says that the comma is meant to return a value, but that value is unused, so that code style is discouraged. I've reverted the code style to the previous one (partial revert of #180), and replaced the remaining commas with semicolons.