### PR TITLE
Allow fast_float to parse strings accepted by the Fortran internal read function.

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -328,9 +328,17 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     return answer;
   }
   int64_t exp_number = 0;            // explicit exponential part
-  if ((fmt & chars_format::scientific) && (p != pend) && ((UC('e') == *p) || (UC('E') == *p))) {
+  if ( ((fmt & chars_format::scientific) &&
+        (p != pend) &&
+        ((UC('e') == *p) || (UC('E') == *p)))
+       ||
+       ((fmt & chars_format::fortran) &&
+        (p != pend) &&
+        ((UC('+') == *p) || (UC('-') == *p) || (UC('d') == *p) || (UC('D') == *p)))) {
     UC const * location_of_e = p;
-    ++p;
+    if ((UC('e') == *p) || (UC('E') == *p) || (UC('d') == *p) || (UC('D') == *p)) {
+      ++p;
+    }
     bool neg_exp = false;
     if ((p != pend) && (UC('-') == *p)) {
       neg_exp = true;

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -16,6 +16,7 @@ enum chars_format {
   scientific = 1 << 0,
   fixed = 1 << 2,
   hex = 1 << 3,
+  fortran = 1 << 4 | fixed | scientific,
   general = fixed | scientific
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,7 +72,7 @@ fast_float_add_cpp_test(long_test)
 fast_float_add_cpp_test(powersoffive_hardround)
 fast_float_add_cpp_test(string_test)
 
-
+fast_float_add_cpp_test(fortran)
 
 option(FASTFLOAT_EXHAUSTIVE "Exhaustive tests" OFF)
 

--- a/tests/fortran.cpp
+++ b/tests/fortran.cpp
@@ -1,0 +1,57 @@
+/*
+ * Exercise the Fortran conversion option.
+ */
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#define FASTFLOAT_ALLOWS_LEADING_PLUS
+
+#include "fast_float/fast_float.h"
+
+int main ()
+{
+  const std::vector<double> expected{ 10000, 1000, 100,  10, 1,    .1, .01, .001, .0001 };
+  const std::vector<std::string> fmt1{ "1+4", "1+3", "1+2", "1+1", "1+0", "1-1", "1-2",
+    "1-3", "1-4" };
+  const std::vector<std::string> fmt2{ "1d+4", "1d+3", "1d+2", "1d+1", "1d+0", "1d-1",
+    "1d-2", "1d-3", "1d-4" };
+  const std::vector<std::string> fmt3{ "+1+4", "+1+3", "+1+2", "+1+1", "+1+0", "+1-1",
+    "+1-2", "+1-3", "+1-4" };
+  const fast_float::parse_options options{ fast_float::chars_format::fortran };
+
+  for ( auto const& f : fmt1 ) {
+    auto d{ std::distance( &fmt1[0], &f ) };
+    double result;
+    auto answer{ fast_float::from_chars_advanced( f.data(), f.data()+f.size(), result,
+                                                  options ) };
+    if ( answer.ec != std::errc() || result != expected[std::size_t(d)] ) {
+      std::cerr << "parsing failure on " << f << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  for ( auto const& f : fmt2 ) {
+    auto d{ std::distance( &fmt2[0], &f ) };
+    double result;
+    auto answer{ fast_float::from_chars_advanced( f.data(), f.data()+f.size(), result,
+                                                  options ) };
+    if ( answer.ec != std::errc() || result != expected[std::size_t(d)] ) {
+      std::cerr << "parsing failure on " << f << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  for ( auto const& f : fmt3 ) {
+    auto d{ std::distance( &fmt3[0], &f ) };
+    double result;
+    auto answer{ fast_float::from_chars_advanced( f.data(), f.data()+f.size(), result,
+                                                  options ) };
+    if ( answer.ec != std::errc() || result != expected[std::size_t(d)] ) {
+      std::cerr << "parsing failure on " << f << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Hi: I'm working on a program which reads an input file which is ordinarily read by a Fortran program. Numbers in the input are converted to binary with the Fortran internal read function. For example, 

CHARACTER(LEN=25) :: CHARS
REAL(KIND=8) :: NUMBER
READ ( CHARS, '(e25.0)' ) NUMBER

The Fortran internal read accepts a larger variety of formats than std::from_chars. In particular, the 'E' in the exponent is optional (!); it can also be replaced with a 'D'. A leading '+' is also accepted. So, "+1+1" is 10.

I made a few changes to fast_float to support this case. I realize it's somewhat out of scope for a C++ function, but it is useful to me.  fast_float is much better than my attempt.

I added a test, but no other CMake infrastructure. Since it does add a condition in parse_number_string, I suppose it slows down the parsing. So, one might want to make it a CMake option and add some conditional #ifdef's. Also, it should #define FASTFLOAT_ALLOWS_LEADING_PLUS. I can add this as an option, but I didn't want to mess with the build infrastructure too much (without approval :-)

This is my first ever Github pull request.

Thanks,
Allen