### PR TITLE
Add support for parsing numbers according to JSON format

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -273,7 +273,6 @@ template <typename UC>
 fastfloat_really_inline FASTFLOAT_CONSTEXPR20
 parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, parse_options_t<UC> options) noexcept {
   chars_format const fmt = options.format;
-  parse_rules const rules = options.rules;
   UC const decimal_point = options.decimal_point;
 
   parsed_number_string_t<UC> answer;
@@ -289,12 +288,11 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     if (p == pend) {
       return answer;
     }
-    if (rules == parse_rules::json) {
+    if (fmt == chars_format::json) {
       if (!is_integer(*p)) { // a sign must be followed by an integer
         return answer;
       }    
     } else {
-      FASTFLOAT_DEBUG_ASSERT(rules == parse_rules::std);
       if (!is_integer(*p) && (*p != decimal_point)) { // a sign must be followed by an integer or the dot
         return answer;
       }
@@ -315,7 +313,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
   int64_t digit_count = int64_t(end_of_integer_part - start_digits);
   answer.integer = span<const UC>(start_digits, size_t(digit_count));
   // disallow leading zeros
-  if (rules == parse_rules::json && start_digits[0] == UC('0') && digit_count > 1) {
+  if (fmt == chars_format::json && start_digits[0] == UC('0') && digit_count > 1) {
     return answer;
   }
 
@@ -342,7 +340,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     return answer;
   }
   // or at least two if a decimal point exists, with json rules
-  else if (rules == parse_rules::json && has_decimal_point && digit_count == 1) {
+  else if (fmt == chars_format::json && has_decimal_point && digit_count == 1) {
     return answer;
   }
   int64_t exp_number = 0;            // explicit exponential part

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -280,7 +280,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
   answer.too_many_digits = false;
   answer.negative = (*p == UC('-'));
 #ifdef FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
-  if ((*p == UC('-')) || (fmt != chars_format::json && *p == UC('+'))) {
+  if ((*p == UC('-')) || (!(fmt & FASTFLOAT_JSONFMT) && *p == UC('+'))) {
 #else
   if (*p == UC('-')) { // C++17 20.19.3.(7.1) explicitly forbids '+' sign here
 #endif
@@ -288,7 +288,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     if (p == pend) {
       return answer;
     }
-    if (fmt == chars_format::json) {
+    if (fmt & FASTFLOAT_JSONFMT) {
       if (!is_integer(*p)) { // a sign must be followed by an integer
         return answer;
       }    
@@ -312,7 +312,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
   UC const * const end_of_integer_part = p;
   int64_t digit_count = int64_t(end_of_integer_part - start_digits);
   answer.integer = span<const UC>(start_digits, size_t(digit_count));
-  if (fmt == chars_format::json) {
+  if (fmt & FASTFLOAT_JSONFMT) {
     // at least 1 digit in integer part, without leading zeros
     if (digit_count == 0 || (start_digits[0] == UC('0') && digit_count > 1)) {
       return answer;
@@ -337,7 +337,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
     answer.fraction = span<const UC>(before, size_t(p - before));
     digit_count -= exponent;
   }
-  if (fmt == chars_format::json) {
+  if (fmt & FASTFLOAT_JSONFMT) {
     // at least 1 digit in fractional part
     if (has_decimal_point && exponent == 0) {
       return answer;

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -280,7 +280,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
   answer.too_many_digits = false;
   answer.negative = (*p == UC('-'));
 #ifdef FASTFLOAT_ALLOWS_LEADING_PLUS // disabled by default
-  if ((*p == UC('-')) || (*p == UC('+'))) {
+  if ((*p == UC('-')) || (fmt != chars_format::json && *p == UC('+'))) {
 #else
   if (*p == UC('-')) { // C++17 20.19.3.(7.1) explicitly forbids '+' sign here
 #endif

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -16,12 +16,8 @@ enum chars_format {
   scientific = 1 << 0,
   fixed = 1 << 2,
   hex = 1 << 3,
+  json = 1 << 4 | fixed | scientific,
   general = fixed | scientific
-};
-
-enum class parse_rules {
-  std,
-  json
 };
 
 template <typename UC>
@@ -34,15 +30,13 @@ using from_chars_result = from_chars_result_t<char>;
 template <typename UC>
 struct parse_options_t {
   constexpr explicit parse_options_t(chars_format fmt = chars_format::general,
-    UC dot = UC('.'), parse_rules prules = parse_rules::std)
-    : format(fmt), decimal_point(dot), rules(prules) {}
+    UC dot = UC('.'))
+    : format(fmt), decimal_point(dot) {}
 
   /** Which number formats are accepted */
   chars_format format;
   /** The character used as decimal point */
   UC decimal_point;
-  /** Rules to use for parsing */
-  parse_rules rules;
 };
 using parse_options = parse_options_t<char>;
 

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -20,6 +20,7 @@ enum chars_format {
   hex = 1 << 3,
   no_infnan = 1 << 4,
   json = FASTFLOAT_JSONFMT | fixed | scientific | no_infnan,
+  json_or_infnan = FASTFLOAT_JSONFMT | fixed | scientific,
   general = fixed | scientific
 };
 

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -19,6 +19,11 @@ enum chars_format {
   general = fixed | scientific
 };
 
+enum class parse_rules {
+  std,
+  json
+};
+
 template <typename UC>
 struct from_chars_result_t {
   UC const* ptr;
@@ -29,13 +34,15 @@ using from_chars_result = from_chars_result_t<char>;
 template <typename UC>
 struct parse_options_t {
   constexpr explicit parse_options_t(chars_format fmt = chars_format::general,
-    UC dot = UC('.'))
-    : format(fmt), decimal_point(dot) {}
+    UC dot = UC('.'), parse_rules prules = parse_rules::std)
+    : format(fmt), decimal_point(dot), rules(prules) {}
 
   /** Which number formats are accepted */
   chars_format format;
   /** The character used as decimal point */
   UC decimal_point;
+  /** Rules to use for parsing */
+  parse_rules rules;
 };
 using parse_options = parse_options_t<char>;
 

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -12,11 +12,14 @@
 
 namespace fast_float {
 
+#define FASTFLOAT_JSONFMT (1 << 5)
+
 enum chars_format {
   scientific = 1 << 0,
   fixed = 1 << 2,
   hex = 1 << 3,
-  json = 1 << 4 | fixed | scientific,
+  no_infnan = 1 << 4,
+  json = FASTFLOAT_JSONFMT | fixed | scientific | no_infnan,
   general = fixed | scientific
 };
 

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -164,7 +164,13 @@ from_chars_result_t<UC> from_chars_advanced(UC const * first, UC const * last,
   }
   parsed_number_string_t<UC> pns = parse_number_string<UC>(first, last, options);
   if (!pns.valid) {
-    return detail::parse_infnan(first, last, value);
+    if (options.format & chars_format::no_infnan) {
+      answer.ec = std::errc::invalid_argument;
+      answer.ptr = first;
+      return answer;
+    } else {
+      return detail::parse_infnan(first, last, value);
+    }
   }
 
   answer.ec = std::errc(); // be optimistic

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,8 @@ fast_float_add_cpp_test(long_test)
 fast_float_add_cpp_test(powersoffive_hardround)
 fast_float_add_cpp_test(string_test)
 
+fast_float_add_cpp_test(json_fmt)
+
 
 
 option(FASTFLOAT_EXHAUSTIVE "Exhaustive tests" OFF)

--- a/tests/json_fmt.cpp
+++ b/tests/json_fmt.cpp
@@ -1,0 +1,38 @@
+
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "fast_float/fast_float.h"
+
+int main()
+{
+  const std::vector<double> expected{ -0.2, 0.02, 0.002, 1., 0. };
+  const std::vector<std::string> accept{ "-0.2", "0.02", "0.002", "1e+0000", "0e-2" };
+  const std::vector<std::string> reject{ "-.2", "00.02", "0.e+1", "00.e+1", ".25"};
+  const auto fmt = fast_float::chars_format::json;
+
+  for (std::size_t i = 0; i < accept.size(); ++i)
+  {
+    const auto& f = accept[i];
+    double result;
+    auto answer = fast_float::from_chars(f.data(), f.data() + f.size(), result, fmt);
+    if (answer.ec != std::errc() || result != expected[i]) {
+      std::cerr << "json fmt rejected valid json " << f << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  for (std::size_t i = 0; i < reject.size(); ++i)
+  {
+    const auto& f = reject[i];
+    double result;
+    auto answer = fast_float::from_chars(f.data(), f.data() + f.size(), result, fmt);
+    if (answer.ec == std::errc()) {
+      std::cerr << "json fmt accepted invalid json " << f << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/json_fmt.cpp
+++ b/tests/json_fmt.cpp
@@ -12,7 +12,7 @@ int main()
 {
   const std::vector<double> expected{ -0.2, 0.02, 0.002, 1., 0. };
   const std::vector<std::string> accept{ "-0.2", "0.02", "0.002", "1e+0000", "0e-2" };
-  const std::vector<std::string> reject{ "-.2", "00.02", "0.e+1", "00.e+1", ".25", "+0.25"};
+  const std::vector<std::string> reject{ "-.2", "00.02", "0.e+1", "00.e+1", ".25", "+0.25", "inf", "nan(snan)"};
   const auto fmt = fast_float::chars_format::json;
 
   for (std::size_t i = 0; i < accept.size(); ++i)

--- a/tests/json_fmt.cpp
+++ b/tests/json_fmt.cpp
@@ -3,13 +3,16 @@
 #include <iostream>
 #include <vector>
 
+// test that this option is ignored
+#define FASTFLOAT_ALLOWS_LEADING_PLUS
+
 #include "fast_float/fast_float.h"
 
 int main()
 {
   const std::vector<double> expected{ -0.2, 0.02, 0.002, 1., 0. };
   const std::vector<std::string> accept{ "-0.2", "0.02", "0.002", "1e+0000", "0e-2" };
-  const std::vector<std::string> reject{ "-.2", "00.02", "0.e+1", "00.e+1", ".25"};
+  const std::vector<std::string> reject{ "-.2", "00.02", "0.e+1", "00.e+1", ".25", "+0.25"};
   const auto fmt = fast_float::chars_format::json;
 
   for (std::size_t i = 0; i < accept.size(); ++i)

--- a/tests/json_fmt.cpp
+++ b/tests/json_fmt.cpp
@@ -10,16 +10,15 @@
 
 int main()
 {
-  const std::vector<double> expected{ -0.2, 0.02, 0.002, 1., 0. };
-  const std::vector<std::string> accept{ "-0.2", "0.02", "0.002", "1e+0000", "0e-2" };
-  const std::vector<std::string> reject{ "-.2", "00.02", "0.e+1", "00.e+1", ".25", "+0.25", "inf", "nan(snan)"};
-  const auto fmt = fast_float::chars_format::json;
+  const std::vector<double> expected{ -0.2, 0.02, 0.002, 1., 0., std::numeric_limits<double>::infinity() };
+  const std::vector<std::string> accept{ "-0.2", "0.02", "0.002", "1e+0000", "0e-2", "inf" };
+  const std::vector<std::string> reject{ "-.2", "00.02", "0.e+1", "00.e+1", ".25", "+0.25", "inf", "nan(snan)" };
 
   for (std::size_t i = 0; i < accept.size(); ++i)
   {
     const auto& f = accept[i];
     double result;
-    auto answer = fast_float::from_chars(f.data(), f.data() + f.size(), result, fmt);
+    auto answer = fast_float::from_chars(f.data(), f.data() + f.size(), result, fast_float::chars_format::json_or_infnan);
     if (answer.ec != std::errc() || result != expected[i]) {
       std::cerr << "json fmt rejected valid json " << f << std::endl;
       return EXIT_FAILURE;
@@ -30,7 +29,7 @@ int main()
   {
     const auto& f = reject[i];
     double result;
-    auto answer = fast_float::from_chars(f.data(), f.data() + f.size(), result, fmt);
+    auto answer = fast_float::from_chars(f.data(), f.data() + f.size(), result, fast_float::chars_format::json);
     if (answer.ec == std::errc()) {
       std::cerr << "json fmt accepted invalid json " << f << std::endl;
       return EXIT_FAILURE;


### PR DESCRIPTION
Details on the format are available here (RFC 8259): https://datatracker.ietf.org/doc/html/rfc8259#section-6
This is compatible with previous JSON RFCs as well as the number format hasn't changed.