### PR TITLE
fix for 32-bit Visual Studio when not set to round to nearest

### DIFF
--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -202,7 +202,7 @@ from_chars_result_t<UC> from_chars_advanced(UC const * first, UC const * last,
       // We do not have that fegetround() == FE_TONEAREST.
       // Next is a modified Clinger's fast path, inspired by Jakub Jelínek's proposal
       if (pns.exponent >= 0 && pns.mantissa <=binary_format<T>::max_mantissa_fast_path(pns.exponent)) {
-#if defined(__clang__)
+#if defined(__clang__) || defined(FASTFLOAT_32BIT)
         // Clang may map 0 to -0.0 when fegetround() == FE_DOWNWARD
         if(pns.mantissa == 0) {
           value = pns.negative ? -0. : 0.;

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -205,7 +205,7 @@ from_chars_result_t<UC> from_chars_advanced(UC const * first, UC const * last,
 #if defined(__clang__) || defined(FASTFLOAT_32BIT)
         // Clang may map 0 to -0.0 when fegetround() == FE_DOWNWARD
         if(pns.mantissa == 0) {
-          value = pns.negative ? -0. : 0.;
+          value = pns.negative ? T(-0.) : T(0.);
           return answer;
         }
 #endif


### PR DESCRIPTION
In some cases, Visual Studio, when compiling 32-bit binaries, gets 0*something == -0 even when the 'something' is positive, if the system is not set to round to nearest.

(This is very narrow and I can't reproduce it locally. The patch is a precaution.)