### PR TITLE
Fix for ARM SIMD

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -134,7 +134,7 @@ using parse_options = parse_options_t<char>;
 #define FASTFLOAT_NEON 1
 #endif
 
-#if defined(FASTFLOAT_SSE2) || defined(FASTFLOAT_ARM64)
+#if defined(FASTFLOAT_SSE2) || defined(FASTFLOAT_NEON)
 #define FASTFLOAT_HAS_SIMD 1
 #endif
 


### PR DESCRIPTION
I think FASTFLOAT_ARM64 is meant to be FASTFLOAT_NEON here.

Without this, FASTFLOAT_HAS_SIMD doesn't get defined for ARM targets, and ARM SIMD doesn't get used in the parser.