### PR TITLE
Use version 6.1.0 instead 6.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 
-project(fast_float VERSION 6.0.0 LANGUAGES CXX)
+project(fast_float VERSION 6.1.0 LANGUAGES CXX)
 set(FASTFLOAT_CXX_STANDARD 11 CACHE STRING "the C++ standard to use for fastfloat")
 set(CMAKE_CXX_STANDARD ${FASTFLOAT_CXX_STANDARD})
 option(FASTFLOAT_TEST "Enable tests" OFF)


### PR DESCRIPTION
Hi there, I would like to ask if is possible to update version in order to sent this patch to [downstream](https://gitlab.archlinux.org/archlinux/packaging/packages/fast_float/-/issues) because if this digits are different generates issues, for example for https://aur.archlinux.org/packages/ants#comment-960051 or any project that has `find_package(VTK)` and has `fast_float-6.1.0`.