### PR TITLE
Add a missing check that __uint128_t exists before using it.

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -331,7 +331,7 @@ value128 full_multiplication(uint64_t a, uint64_t b) {
   answer.low = a * b;
 #elif defined(FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))
   answer.low = _umul128(a, b, &answer.high); // _umul128 not available on ARM64
-#elif defined(FASTFLOAT_64BIT)
+#elif defined(FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
   __uint128_t r = ((__uint128_t)a) * b;
   answer.low = uint64_t(r);
   answer.high = uint64_t(r >> 64);


### PR DESCRIPTION
I noticed a compilation error when building a 64-bit binary with this library while using xlclang on AIX, and this change seems to fix it.