### PR TITLE
Disallow empty exponent in JSON parsing

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -349,7 +349,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
       ++p;
     }
     if ((p == pend) || !is_integer(*p)) {
-      if(!(fmt & chars_format::fixed)) {
+      if(!(fmt & chars_format::fixed) || (fmt & FASTFLOAT_JSONFMT)) {
         // We are in error.
         return answer;
       }

--- a/tests/json_fmt.cpp
+++ b/tests/json_fmt.cpp
@@ -40,7 +40,9 @@ int main()
 {
   const std::vector<double> expected{ -0.2, 0.02, 0.002, 1., 0., std::numeric_limits<double>::infinity() };
   const std::vector<std::string> accept{ "-0.2", "0.02", "0.002", "1e+0000", "0e-2", "inf" };
-  const std::vector<std::string> reject{ "-.2", "00.02", "0.e+1", "00.e+1", ".25", "+0.25", "inf", "nan(snan)" };
+  const std::vector<std::string> reject{"-.2", "00.02",    "0.e+1", "00.e+1",
+                                        "1e",  "1e+",      ".25",   "+0.25",
+                                        "inf", "nan(snan)"};
 
   for (std::size_t i = 0; i < accept.size(); ++i)
   {


### PR DESCRIPTION
The JSON spec requires at least one digit in the exponential part, if
specified.
