### PR TITLE
Allow JSON empty exponent as trailing junk

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -349,7 +349,7 @@ parsed_number_string_t<UC> parse_number_string(UC const *p, UC const * pend, par
       ++p;
     }
     if ((p == pend) || !is_integer(*p)) {
-      if(!(fmt & chars_format::fixed) || (fmt & FASTFLOAT_JSONFMT)) {
+      if(!(fmt & chars_format::fixed)) {
         // We are in error.
         return answer;
       }


### PR DESCRIPTION
Revert #251, and instead allow an invalid trailing empty exponent to be
treated as junk data in JSON parsing. Expand the test suite to test this
case, including testing the trailing junk.
