### PR TITLE
Include intrin.h for __umulh

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -84,7 +84,8 @@ using parse_options = parse_options_t<char>;
   #endif
 #endif
 
-#if ((defined(_WIN32) || defined(_WIN64)) && !defined(__clang__))
+#if ((defined(_WIN32) || defined(_WIN64)) && !defined(__clang__)) || \
+    (defined(_M_ARM64) && !defined(__MINGW32__))
 #include <intrin.h>
 #endif
 


### PR DESCRIPTION
Arm64 uses __umulh, so add the same condition for including the intrin.h header.

This was failing when trying to pull fast_float into Chromium (https://ci.chromium.org/ui/p/chromium/builders/try/win-arm64-compile-dbg/131424/overview)