### PR TITLE
Support aarch64-w64-mingw32 target

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -344,6 +344,8 @@ full_multiplication(uint64_t a, uint64_t b) {
   answer.high = __umulh(a, b);
   answer.low = a * b;
 #elif defined(FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))
+#elif defined(FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__) \
+  && !defined(_M_ARM64))
   answer.low = _umul128(a, b, &answer.high); // _umul128 not available on ARM64
 #elif defined(FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
   __uint128_t r = ((__uint128_t)a) * b;

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -343,9 +343,8 @@ full_multiplication(uint64_t a, uint64_t b) {
   // But MinGW on ARM64 doesn't have native support for 64-bit multiplications
   answer.high = __umulh(a, b);
   answer.low = a * b;
-#elif defined(FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__))
-#elif defined(FASTFLOAT_32BIT) || (defined(_WIN64) && !defined(__clang__) \
-  && !defined(_M_ARM64))
+#elif defined(FASTFLOAT_32BIT) ||                                              \
+    (defined(_WIN64) && !defined(__clang__) && !defined(_M_ARM64))
   answer.low = _umul128(a, b, &answer.high); // _umul128 not available on ARM64
 #elif defined(FASTFLOAT_64BIT) && defined(__SIZEOF_INT128__)
   __uint128_t r = ((__uint128_t)a) * b;


### PR DESCRIPTION
The patch resolves GCC compilation issues for the C++ language targeting
aarch64-w64-mingw32.

More information could be found here:
https://gcc.gnu.org/pipermail/gcc-patches/2024-September/662020.html
