### PR TITLE
doctest: if SYSTEM_DOCTEST add a `find_package(doctest REQUIRED)`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,8 @@ if (NOT SYSTEM_DOCTEST)
   FetchContent_Declare(doctest
     GIT_REPOSITORY https://github.com/onqtam/doctest.git
     GIT_TAG v2.4.11)
+else ()
+  find_package(doctest REQUIRED)
 endif()
 if (FASTFLOAT_SUPPLEMENTAL_TESTS)
   FetchContent_Declare(supplemental_test_files
@@ -59,6 +61,8 @@ function(fast_float_add_cpp_test TEST_NAME)
     target_link_libraries(${TEST_NAME} PUBLIC fast_float supplemental-data)
     if (NOT SYSTEM_DOCTEST)
       target_link_libraries(${TEST_NAME} PUBLIC doctest)
+    else ()
+      target_link_libraries(${TEST_NAME} PUBLIC doctest::doctest)
     endif()
 endfunction(fast_float_add_cpp_test)
 


### PR DESCRIPTION
Hi, I've been working on [packaging](https://github.com/spack/spack/pull/46137) fast-float for Spack, including tests. Since Spack aims to avoid vendored dependencies, it installs doctest separately in its own prefix and not in the system location. By adding a `find_package(doctest)` statement, as recommended in the [doctest documentation](https://github.com/doctest/doctest/blob/master/doc/markdown/build-systems.md), fast-float can successfully locate the package, allowing us to build and run the tests properly. 

I made minimal changes to easily patch older versions. 