### PR TITLE
Prevent amalgamate.py from adding trailing whitespace

### DIFF
--- a/script/amalgamate.py
+++ b/script/amalgamate.py
@@ -27,7 +27,10 @@ for filename in ['LICENSE-MIT', 'LICENSE-APACHE', 'LICENSE-BOOST']:
 
   text = ''
   for line in lines:
-    text += '//    ' + line.strip() + '\n'
+    line = line.strip()
+    if len(line):
+      line = '    ' + line
+    text += '//' + line + '\n'
   processed_files[filename] = text
 
 # code


### PR DESCRIPTION
When adding the license text, only add leading whitespace to non-empty lines, otherwise it becomes trailing whitespace.

Tested with each `--license` option to verify the only changes in the generated output are removing the unwanted trailing whitespace.