### PR TITLE
Add Bazel build rules.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+build --cxxopt="--std=c++17"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/*
 Testing/*
 .cache/
 compile_commands.json
+bazel-*
 
 # Visual studio
 .vs/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,6 @@
+cc_library(
+    name = "fast_float",
+    hdrs = glob(["include/fast_float/*.h"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,9 @@
+"""fast_float number parsing library: 4x faster than strtod"""
+
+module(
+    name = "fast_float",
+    version = "6.1.6",
+    compatibility_level = 6,
+)
+
+bazel_dep(name = "doctest", version = "2.4.11", dev_dependency = True)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,0 +1,98 @@
+cc_test(
+    name = "basictest",
+    srcs = ["basictest.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "example_test",
+    srcs = ["example_test.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "example_comma_test",
+    srcs = ["example_comma_test.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "fast_int",
+    srcs = ["fast_int.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "fixedwidthtest",
+    srcs = ["fixedwidthtest.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "fortran",
+    srcs = ["fortran.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "json_fmt",
+    srcs = ["json_fmt.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "long_test",
+    srcs = ["long_test.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "powersoffive_hardround",
+    srcs = ["powersoffive_hardround.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "rcppfastfloat_test",
+    srcs = ["rcppfastfloat_test.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)
+
+cc_test(
+    name = "string_test",
+    srcs = ["string_test.cpp"],
+    deps = [
+        "//:fast_float",
+        "@doctest//doctest",
+    ],
+)

--- a/tests/basictest.cpp
+++ b/tests/basictest.cpp
@@ -1,6 +1,6 @@
 #define DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <doctest/doctest.h>
+#include "doctest/doctest.h"
 
 #include "fast_float/fast_float.h"
 #include <cmath>

--- a/tests/fixedwidthtest.cpp
+++ b/tests/fixedwidthtest.cpp
@@ -4,7 +4,10 @@
 #include <cstring>
 #include "fast_float/fast_float.h"
 #include <cstdint>
+
+#if __cplusplus >= 202300L
 #include <stdfloat>
+#endif
 
 int main() {
   // Write some testcases for the parsing of floating point numbers in the


### PR DESCRIPTION
Similar to https://github.com/lemire/fast_double_parser/pull/79, I would like to contribute this excellent library to Bazel. Please take a look.

`build --cxxopt="--std=c++17"` set in `.bazelrc` only affects the tests. When the library is imported by other project, they can specify whatever C++ version.