### PR TITLE
Adding new loop_parse_if_digits function

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -224,9 +224,7 @@ bool simd_parse_if_eight_digits_unrolled(UC const *, uint64_t &) {
 template <typename UC, FASTFLOAT_ENABLE_IF(!std::is_same<UC, char>::value) = 0>
 fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
 loop_parse_if_eight_digits(UC const *&p, UC const *const pend, uint64_t &i) {
-  FASTFLOAT_IF_CONSTEXPR(!has_simd_opt<UC>()) {
-    return;
-  }
+  FASTFLOAT_IF_CONSTEXPR(!has_simd_opt<UC>()) { return; }
   while (((pend - p) >= 8) &&
          simd_parse_if_eight_digits_unrolled(
              p, i)) { // in rare cases, this will overflow, but that's ok
@@ -249,9 +247,7 @@ loop_parse_if_eight_digits(char const *&p, char const *const pend,
 template <typename UC, FASTFLOAT_ENABLE_IF(!std::is_same<UC, char>::value) = 0>
 fastfloat_really_inline FASTFLOAT_CONSTEXPR20 void
 loop_parse_if_digits(UC const *&p, UC const *const pend, uint64_t &i) {
-  FASTFLOAT_IF_CONSTEXPR(!has_simd_opt<UC>()) {
-    return;
-  }
+  FASTFLOAT_IF_CONSTEXPR(!has_simd_opt<UC>()) { return; }
   while (((pend - p) >= 8) &&
          simd_parse_if_eight_digits_unrolled(
              p, i)) { // in rare cases, this will overflow, but that's ok

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -32,7 +32,7 @@ template <typename UC> fastfloat_really_inline constexpr bool has_simd_opt() {
 // able to optimize it well.
 template <typename UC>
 fastfloat_really_inline constexpr bool is_integer(UC c) noexcept {
-  return static_cast<uint8_t>(c - '0') < 10;
+  return static_cast<uint8_t>(c - UC('0')) < 10;
 }
 
 fastfloat_really_inline constexpr uint64_t byteswap(uint64_t val) {

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -28,11 +28,20 @@ template <typename UC> fastfloat_really_inline constexpr bool has_simd_opt() {
 #endif
 }
 
+template <typename value_type> struct get_equal_sized_uint {
+  using type = std::conditional_t<
+      sizeof(value_type) == 4, uint32_t,
+      std::conditional_t<sizeof(value_type) == 2, uint16_t, uint8_t>>;
+};
+
+template <typename value_type>
+using get_equal_sized_uint_t = typename get_equal_sized_uint<value_type>::type;
+
 // Next function can be micro-optimized, but compilers are entirely
 // able to optimize it well.
 template <typename UC>
 fastfloat_really_inline constexpr bool is_integer(UC c) noexcept {
-  return static_cast<uint8_t>(c - UC('0')) < 10;
+  return static_cast<get_equal_sized_uint_t<UC>>(c - UC('0')) < 10;
 }
 
 fastfloat_really_inline constexpr uint64_t byteswap(uint64_t val) {

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -29,9 +29,9 @@ template <typename UC> fastfloat_really_inline constexpr bool has_simd_opt() {
 }
 
 template <typename value_type> struct get_equal_sized_uint {
-  using type = std::conditional_t<
+  using type = FASTFLOAT_CONDITIONAL_T(
       sizeof(value_type) == 4, uint32_t,
-      std::conditional_t<sizeof(value_type) == 2, uint16_t, uint8_t>>;
+      FASTFLOAT_CONDITIONAL_T(sizeof(value_type) == 2, uint16_t, uint8_t));
 };
 
 template <typename value_type>

--- a/include/fast_float/constexpr_feature_detect.h
+++ b/include/fast_float/constexpr_feature_detect.h
@@ -15,7 +15,7 @@
 #endif
 
 #if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-#define FASTFLOAT_IF_CONSTEXPR if constexpr 
+#define FASTFLOAT_IF_CONSTEXPR if constexpr
 #else
 #define FASTFLOAT_IF_CONSTEXPR if
 #endif

--- a/include/fast_float/constexpr_feature_detect.h
+++ b/include/fast_float/constexpr_feature_detect.h
@@ -14,7 +14,7 @@
 #define FASTFLOAT_CONSTEXPR14
 #endif
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
 #define FASTFLOAT_IF_CONSTEXPR if constexpr 
 #else
 #define FASTFLOAT_IF_CONSTEXPR if

--- a/include/fast_float/constexpr_feature_detect.h
+++ b/include/fast_float/constexpr_feature_detect.h
@@ -14,6 +14,12 @@
 #define FASTFLOAT_CONSTEXPR14
 #endif
 
+#if __cplusplus >= 201703L
+#define FASTFLOAT_IF_CONSTEXPR if constexpr 
+#else
+#define FASTFLOAT_IF_CONSTEXPR if
+#endif
+
 #if defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L
 #define FASTFLOAT_HAS_BIT_CAST 1
 #else

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -883,6 +883,40 @@ operator^=(chars_format &lhs, chars_format rhs) noexcept {
   return lhs = (lhs ^ rhs);
 }
 
+#if defined(_MSC_VER)
+#if _MSC_VER >= 1900
+#if _MSC_VER >= 1910
+#else
+#define CPP14_NOT_SUPPORTED
+#endif
+#else
+#define CPP14_NOT_SUPPORTED
+#endif
+#elif __cplusplus < 201402L
+#define CPP14_NOT_SUPPORTED
+#endif
+
+#ifndef CPP14_NOT_SUPPORTED
+#define FASTFLOAT_CONDITIONAL_T(condition, true_t, false_t)                    \
+  std::conditional_t<condition, true_t, false_t>
+#else
+template <bool condition, typename true_t, typename false_t>
+struct conditional {
+  using type = false_t;
+};
+
+template <typename true_t, typename false_t>
+struct conditional<true, true_t, false_t> {
+  using type = true_t;
+};
+
+template <bool condition, typename true_t, typename false_t>
+using conditional_t = typename conditional<condition, true_t, false_t>::type;
+
+#define FASTFLOAT_CONDITIONAL_T(condition, true_t, false_t)                    \
+  conditional_t<condition, true_t, false_t>
+#endif
+
 namespace detail {
 // adjust for deprecated feature macros
 constexpr chars_format adjust_for_feature_macros(chars_format fmt) {

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -189,12 +189,16 @@ using parse_options = parse_options_t<char>;
 
 #ifndef FASTFLOAT_ASSERT
 #define FASTFLOAT_ASSERT(x)                                                    \
-  { ((void)(x)); }
+  {                                                                            \
+    ((void)(x));                                                               \
+  }
 #endif
 
 #ifndef FASTFLOAT_DEBUG_ASSERT
 #define FASTFLOAT_DEBUG_ASSERT(x)                                              \
-  { ((void)(x)); }
+  {                                                                            \
+    ((void)(x));                                                               \
+  }
 #endif
 
 // rust style `try!()` macro, or `?` operator


### PR DESCRIPTION
We can eliminate one of the subtractions from within is_made_of_eight_digits_fast and parse_eight_digits_unrolled by instead moving it out into when the value is collected. Additionally, we can also save some overhead by not collecting the value twice for each iteration of the loop within loop_parse_if_eight_digits.

The new function results in the following benchmark scores:
https://pastebin.com/raw/EQJvPF5G
with the following code:
https://github.com/RealTimeChris/BenchmarkSuite/blob/loop_parse_if_digits/StringComparison/main.cpp
