### PR TITLE
Silenced Visual Studio compiler warning

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -482,7 +482,14 @@ parse_int_string(UC const *p, UC const *pend, T &value,
   UC const *const first = p;
 
   bool const negative = (*p == UC('-'));
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#pragma warning(push)
+#pragma warning(disable : 4127)
+#endif
   if (!std::is_signed<T>::value && negative) {
+#ifdef FASTFLOAT_VISUAL_STUDIO
+#pragma warning(pop)
+#endif
     answer.ec = std::errc::invalid_argument;
     answer.ptr = first;
     return answer;


### PR DESCRIPTION
This code caused a C4127 "conditional expression is constant" compiler warning when compiled with Visual Studio at warning level 4 with T a signed integer type.

