### PR TITLE
fix /permissive- flag causing a compile error on clang for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,13 +55,14 @@ if(FASTFLOAT_SANITIZE)
     target_link_libraries(fast_float INTERFACE -fuse-ld=gold)
   endif()
 endif()
-if(MSVC_VERSION GREATER 1910)
-  # /permissive- will only work on MSVC or clang-cl, clang will not accept it.
-  if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-    target_compile_options(fast_float INTERFACE /permissive-)
-  endif()
-endif()
 
+include(CheckCXXCompilerFlag)
+unset(FASTFLOAT_COMPILER_SUPPORTS_PERMISSIVE)
+CHECK_CXX_COMPILER_FLAG(/permissive- FASTFLOAT_COMPILER_SUPPORTS_PERMISSIVE)
+
+if(FASTFLOAT_COMPILER_SUPPORTS_PERMISSIVE)
+  target_compile_options(fast_float INTERFACE /permissive-)
+endif()
 
 if(FASTFLOAT_INSTALL)
   include(CMakePackageConfigHelpers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,10 @@ if(FASTFLOAT_SANITIZE)
   endif()
 endif()
 if(MSVC_VERSION GREATER 1910)
-  target_compile_options(fast_float INTERFACE /permissive-)
+  # /permissive- will only work on MSVC or clang-cl, clang will not accept it.
+  if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+    target_compile_options(fast_float INTERFACE /permissive-)
+  endif()
 endif()
 
 


### PR DESCRIPTION
When using the library with Clang on Windows (not clang-cl and not MSYS2), an error is thrown by the compiler:

```
clang: error: no such file or directory: '/permissive-'
```

This is caused by these lines in `CMakeLists.txt`:

```cmake
if(MSVC_VERSION GREATER 1910)
  target_compile_options(fast_float INTERFACE /permissive-)
endif()
```

Clang on Windows defines `MSVC_VERSION`, but does not support MSVC-like compiler flags. This PR adds an extra check to make sure the flag is only added when the used compiler supports it.

Presumably fixes #304, although it seems that CI only has MSYS2 Clang and MSVC Clang-cl workflows, neither of which are impacted by this issue, so I've only verified that it works on my machine.