### PR TITLE
turning json option into macro parameter

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -236,7 +236,7 @@ int main(int argc, char **argv) {
               << std::endl;
 #endif
   }
-  if(argc > 1) {
+  if (argc > 1) {
     fileload(argv[1]);
     return EXIT_SUCCESS;
   }

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -299,7 +299,7 @@ parse_number_string(UC const *p, UC const *pend,
       return report_parse_error<UC>(
           p, parse_error::missing_integer_or_dot_after_sign);
     }
-    if (basic_json_fmt) {
+    FASTFLOAT_IF_CONSTEXPR17(basic_json_fmt) {
       if (!is_integer(*p)) { // a sign must be followed by an integer
         return report_parse_error<UC>(p,
                                       parse_error::missing_integer_after_sign);
@@ -328,7 +328,7 @@ parse_number_string(UC const *p, UC const *pend,
   UC const *const end_of_integer_part = p;
   int64_t digit_count = int64_t(end_of_integer_part - start_digits);
   answer.integer = span<UC const>(start_digits, size_t(digit_count));
-  if (basic_json_fmt) {
+  FASTFLOAT_IF_CONSTEXPR17(basic_json_fmt) {
     // at least 1 digit in integer part, without leading zeros
     if (digit_count == 0) {
       return report_parse_error<UC>(p, parse_error::no_digits_in_integer_part);
@@ -357,7 +357,7 @@ parse_number_string(UC const *p, UC const *pend,
     answer.fraction = span<UC const>(before, size_t(p - before));
     digit_count -= exponent;
   }
-  if (basic_json_fmt) {
+  FASTFLOAT_IF_CONSTEXPR17(basic_json_fmt) {
     // at least 1 digit in fractional part
     if (has_decimal_point && exponent == 0) {
       return report_parse_error<UC>(p,

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -279,7 +279,7 @@ report_parse_error(UC const *p, parse_error error) {
 
 // Assuming that you use no more than 19 digits, this will
 // parse an ASCII string.
-template <typename UC>
+template <bool basic_json_fmt, typename UC>
 fastfloat_really_inline FASTFLOAT_CONSTEXPR20 parsed_number_string_t<UC>
 parse_number_string(UC const *p, UC const *pend,
                     parse_options_t<UC> options) noexcept {
@@ -294,13 +294,13 @@ parse_number_string(UC const *p, UC const *pend,
   // C++17 20.19.3.(7.1) explicitly forbids '+' sign here
   if ((*p == UC('-')) ||
       (uint64_t(fmt & chars_format::allow_leading_plus) &&
-       !uint64_t(fmt & detail::basic_json_fmt) && *p == UC('+'))) {
+       !basic_json_fmt && *p == UC('+'))) {
     ++p;
     if (p == pend) {
       return report_parse_error<UC>(
           p, parse_error::missing_integer_or_dot_after_sign);
     }
-    if (uint64_t(fmt & detail::basic_json_fmt)) {
+    if (basic_json_fmt) {
       if (!is_integer(*p)) { // a sign must be followed by an integer
         return report_parse_error<UC>(p,
                                       parse_error::missing_integer_after_sign);
@@ -329,7 +329,7 @@ parse_number_string(UC const *p, UC const *pend,
   UC const *const end_of_integer_part = p;
   int64_t digit_count = int64_t(end_of_integer_part - start_digits);
   answer.integer = span<UC const>(start_digits, size_t(digit_count));
-  if (uint64_t(fmt & detail::basic_json_fmt)) {
+  if (basic_json_fmt) {
     // at least 1 digit in integer part, without leading zeros
     if (digit_count == 0) {
       return report_parse_error<UC>(p, parse_error::no_digits_in_integer_part);
@@ -358,7 +358,7 @@ parse_number_string(UC const *p, UC const *pend,
     answer.fraction = span<UC const>(before, size_t(p - before));
     digit_count -= exponent;
   }
-  if (uint64_t(fmt & detail::basic_json_fmt)) {
+  if (basic_json_fmt) {
     // at least 1 digit in fractional part
     if (has_decimal_point && exponent == 0) {
       return report_parse_error<UC>(p,

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -292,9 +292,8 @@ parse_number_string(UC const *p, UC const *pend,
   // assume p < pend, so dereference without checks;
   answer.negative = (*p == UC('-'));
   // C++17 20.19.3.(7.1) explicitly forbids '+' sign here
-  if ((*p == UC('-')) ||
-      (uint64_t(fmt & chars_format::allow_leading_plus) &&
-       !basic_json_fmt && *p == UC('+'))) {
+  if ((*p == UC('-')) || (uint64_t(fmt & chars_format::allow_leading_plus) &&
+                          !basic_json_fmt && *p == UC('+'))) {
     ++p;
     if (p == pend) {
       return report_parse_error<UC>(

--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -304,7 +304,8 @@ parse_number_string(UC const *p, UC const *pend,
         return report_parse_error<UC>(p,
                                       parse_error::missing_integer_after_sign);
       }
-    } else {
+    }
+    else {
       if (!is_integer(*p) &&
           (*p !=
            decimal_point)) { // a sign must be followed by an integer or the dot
@@ -363,8 +364,8 @@ parse_number_string(UC const *p, UC const *pend,
       return report_parse_error<UC>(p,
                                     parse_error::no_digits_in_fractional_part);
     }
-  } else if (digit_count ==
-             0) { // we must have encountered at least one integer!
+  }
+  else if (digit_count == 0) { // we must have encountered at least one integer!
     return report_parse_error<UC>(p, parse_error::no_digits_in_mantissa);
   }
   int64_t exp_number = 0; // explicit exponential part

--- a/include/fast_float/constexpr_feature_detect.h
+++ b/include/fast_float/constexpr_feature_detect.h
@@ -27,6 +27,12 @@
 #define FASTFLOAT_HAS_IS_CONSTANT_EVALUATED 0
 #endif
 
+#if defined(__cpp_if_constexpr) && __cpp_if_constexpr >= 201606L
+#define FASTFLOAT_IF_CONSTEXPR17(x) if constexpr (x)
+#else
+#define FASTFLOAT_IF_CONSTEXPR17(x) if (x)
+#endif
+
 // Testing for relevant C++20 constexpr library features
 #if FASTFLOAT_HAS_IS_CONSTANT_EVALUATED && FASTFLOAT_HAS_BIT_CAST &&           \
     defined(__cpp_lib_constexpr_algorithms) &&                                 \

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -304,9 +304,10 @@ from_chars_float_advanced(UC const *first, UC const *last, T &value,
     answer.ptr = first;
     return answer;
   }
-  parsed_number_string_t<UC> pns = uint64_t(fmt & detail::basic_json_fmt) ? 
-  parse_number_string<true, UC>(first, last, options) :
-  parse_number_string<false, UC>(first, last, options);
+  parsed_number_string_t<UC> pns =
+      uint64_t(fmt & detail::basic_json_fmt)
+          ? parse_number_string<true, UC>(first, last, options)
+          : parse_number_string<false, UC>(first, last, options);
   if (!pns.valid) {
     if (uint64_t(fmt & chars_format::no_infnan)) {
       answer.ec = std::errc::invalid_argument;

--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -304,8 +304,9 @@ from_chars_float_advanced(UC const *first, UC const *last, T &value,
     answer.ptr = first;
     return answer;
   }
-  parsed_number_string_t<UC> pns =
-      parse_number_string<UC>(first, last, options);
+  parsed_number_string_t<UC> pns = uint64_t(fmt & detail::basic_json_fmt) ? 
+  parse_number_string<true, UC>(first, last, options) :
+  parse_number_string<false, UC>(first, last, options);
   if (!pns.valid) {
     if (uint64_t(fmt & chars_format::no_infnan)) {
       answer.ec = std::errc::invalid_argument;

--- a/tests/json_fmt.cpp
+++ b/tests/json_fmt.cpp
@@ -131,7 +131,7 @@ int main() {
   for (std::size_t i = 0; i < reject.size(); ++i) {
     auto const &f = reject[i].input;
     auto const &expected_reason = reject[i].reason;
-    auto answer = fast_float::parse_number_string(
+    auto answer = fast_float::parse_number_string<true>(
         f.data(), f.data() + f.size(),
         fast_float::parse_options(
             fast_float::chars_format::json |


### PR DESCRIPTION

We have added a few options (such as  json_fmt). These trigger a short series of branches in our `parse_number_string` function. Unfortunately, this is costing us a bit of performance. We can get it back by turning the runtime parameters into template parameters... there is still a branch, but it is more direct and likely extremely cheap.

Building:

```
cmake -B build -D FASTFLOAT_BENCHMARKS=ON
cmake --build build
```

Let us benchmark on an Apple M2 processor (LLVM 16). These benchmarks are part of our library.

Before:

```
⚡  ./build/benchmarks/realbenchmark
####
# reading /Users/dlemire/CVS/github/fast_float/bui/benchmarks/data/canada.txt
####
# read 111126 lines
ASCII volume = 1.93374 MB
fastfloat (64)                          :  1166.05 MB/s (+/- 8.5 %)    67.01 Mfloat/s
fastfloat (32)                          :  1211.52 MB/s (+/- 7.5 %)    69.62 Mfloat/s
UTF-16 volume = 3.86749 MB
fastfloat (64)                          :  2187.60 MB/s (+/- 5.6 %)    62.86 Mfloat/s
fastfloat (32)                          :  2269.15 MB/s (+/- 4.6 %)    65.20 Mfloat/s
####
# reading /Users/dlemire/CVS/github/fast_float/bui/benchmarks/data/mesh.txt
####
# read 73019 lines
ASCII volume = 0.536009 MB
fastfloat (64)                          :   773.74 MB/s (+/- 4.7 %)   105.40 Mfloat/s
fastfloat (32)                          :   686.86 MB/s (+/- 4.3 %)    93.57 Mfloat/s
UTF-16 volume = 1.07202 MB
fastfloat (64)                          :  1551.87 MB/s (+/- 4.8 %)   105.70 Mfloat/s
fastfloat (32)                          :  1396.92 MB/s (+/- 6.0 %)    95.15 Mfloat/s
```

After:

```
⚡  ./build/benchmarks/realbenchmark
####
# reading /Users/dlemire/CVS/github/fast_float/build/benchmarks/data/canada.txt
####
# read 111126 lines
ASCII volume = 1.93374 MB
fastfloat (64)                          :  1175.62 MB/s (+/- 4.9 %)    67.56 Mfloat/s
fastfloat (32)                          :  1224.92 MB/s (+/- 4.1 %)    70.39 Mfloat/s
UTF-16 volume = 3.86749 MB
fastfloat (64)                          :  2220.99 MB/s (+/- 4.4 %)    63.82 Mfloat/s
fastfloat (32)                          :  2292.35 MB/s (+/- 4.4 %)    65.87 Mfloat/s
####
# reading /Users/dlemire/CVS/github/fast_float/build/benchmarks/data/mesh.txt
####
# read 73019 lines
ASCII volume = 0.536009 MB
fastfloat (64)                          :   873.69 MB/s (+/- 2.0 %)   119.02 Mfloat/s
fastfloat (32)                          :   785.65 MB/s (+/- 4.3 %)   107.03 Mfloat/s
UTF-16 volume = 1.07202 MB
fastfloat (64)                          :  1638.44 MB/s (+/- 1.8 %)   111.60 Mfloat/s
fastfloat (32)                          :  1548.04 MB/s (+/- 4.2 %)   105.44 Mfloat/s
```

On the mesh dataset, we get a performance boost of about 15%. 


This might be related to PR https://github.com/fastfloat/fast_float/pull/307 by @IRainman
