### PR TITLE
README: Add xmake repository reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ cmake --build build
   manager](https://conan.io/center/recipes/fast_float).
 * It is part of the [brew package
   manager](https://formulae.brew.sh/formula/fast_float).
+* fast_float is available on [xmake](https://xmake.io) repository.
 * Some Linux distribution like Fedora include fast_float (e.g., as
   `fast_float-devel`).
 


### PR DESCRIPTION
Hello

fast_float is now part of [xmake](https://xmake.io) repository here: https://github.com/xmake-io/xmake-repo/blob/dev/packages/f/fast_float/xmake.lua

