### PR TITLE
Added template overloads for `integer_times_pow10()`

### DIFF
--- a/include/fast_float/fast_float.h
+++ b/include/fast_float/fast_float.h
@@ -64,6 +64,20 @@ FASTFLOAT_CONSTEXPR20 inline double
 integer_times_pow10(int64_t mantissa, int decimal_exponent) noexcept;
 
 /**
+ * This function is a template overload of `integer_times_pow10()`
+ * that returns a floating-point value of type `T` that is one of
+ * supported floating-point types (e.g. `double`, `float`).
+ */
+template <typename T>
+FASTFLOAT_CONSTEXPR20
+    typename std::enable_if<is_supported_float_type<T>::value, T>::type
+    integer_times_pow10(uint64_t mantissa, int decimal_exponent) noexcept;
+template <typename T>
+FASTFLOAT_CONSTEXPR20
+    typename std::enable_if<is_supported_float_type<T>::value, T>::type
+    integer_times_pow10(int64_t mantissa, int decimal_exponent) noexcept;
+
+/**
  * from_chars for integer types.
  */
 template <typename T, typename UC = char,


### PR DESCRIPTION
Since the question was raised in #320, I added template overloads for `integer_times_pow10()`.

Usage:
```c++
const auto a = fast_float::integer_times_pow10(23, 42); // a is a double
const auto d = fast_float::integer_times_pow10<double>(23, 42); // d is a double
const auto f = fast_float::integer_times_pow10<float>(23, 42); // f is a float
```

Thins to pay attention to:
* please see comments in files.

Will add some docs to README later.