### PR TITLE
README.md: update repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ framework](https://github.com/microsoft/LightGBM).
 Packages
 ------
 
-[![Packaging status](https://repology.org/badge/vertical-allrepos/fastfloat.svg)](https://repology.org/project/fastfloat/versions)
+[![Packaging status](https://repology.org/badge/vertical-allrepos/fast-float.svg)](https://repology.org/project/fast-float/versions)
 
 
 ## References


### PR DESCRIPTION
The fast_float packaging is named differently across different Linux distros. Repology has consolidated that to a single page which is different than the page used in this project's README.md. This fixes that.