### PR TITLE
Add Bazel updates configuration to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,14 @@
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
 version: 2
 updates:
+  - package-ecosystem: bazel
+    directory: /
+    groups:
+      bazel:
+        patterns:
+          - "*"  # Group all Bzlmod updates into a single larger pull request
+    schedule:
+      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     groups:


### PR DESCRIPTION
#### Description

Add Bazel updates configuration to Dependabot

See https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#supported-ecosystems-and-repositories
