### PR TITLE
oss-fuzz: Add unit test build

### DIFF
--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -6,3 +6,7 @@ $CXX $CFLAGS $CXXFLAGS \
 
 $CXX $CFLAGS $CXXFLAGS $LIB_FUZZING_ENGINE from_chars.o \
      -o $OUT/from_chars
+
+# Build unit tests
+cmake -DFASTFLOAT_TEST=ON -DCMAKE_EXE_LINKER_FLAGS="-lpthread"
+make


### PR DESCRIPTION
OSS-Fuzz has a new Chronos feature that allows fast rebuilding of OSS-Fuzz-integrated projects and checks whether the project code or fuzzers still pass their unit tests after patching. To enable this feature, the unit tests of integrated projects need to be built. Therefore, this PR modifies the build script used by OSS-Fuzz to also build the unit tests for this project. The OSS-Fuzz-side changes for this project's integration can be found here: https://github.com/google/oss-fuzz/pull/14582.