### PR TITLE
Replace std::min with ternary operators to avoid <algorithm> dependency

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -594,7 +594,7 @@ parse_int_string(UC const *p, UC const *pend, T &value,
           ((digits + 0x46464646u) | (digits - 0x30303030u)) & 0x80808080u;
       uint32_t tz = (uint32_t)countr_zero_32(magic); // 7, 15, 23, 31, or 32
       uint32_t nd = (tz == 32) ? 4 : (tz >> 3);
-      nd = (uint32_t)std::min((size_t)nd, len);
+      nd = (uint32_t)(nd < len ? nd : len);
       if (nd == 0) {
         if (has_leading_zeros) {
           value = 0;

--- a/include/fast_float/digit_comparison.h
+++ b/include/fast_float/digit_comparison.h
@@ -1,7 +1,6 @@
 #ifndef FASTFLOAT_DIGIT_COMPARISON_H
 #define FASTFLOAT_DIGIT_COMPARISON_H
 
-#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <iterator>
@@ -109,7 +108,7 @@ fastfloat_really_inline FASTFLOAT_CONSTEXPR14 void round(adjusted_mantissa &am,
   if (-am.power2 >= mantissa_shift) {
     // have a denormal float
     int32_t shift = -am.power2 + 1;
-    cb(am, std::min<int32_t>(shift, 64));
+    cb(am, (shift < 64 ? shift : 64));
     // check for round-up: if rounding-nearest carried us to the hidden bit.
     am.power2 = (am.mantissa <
                  (uint64_t(1) << binary_format<T>::mantissa_explicit_bits()))

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -1,7 +1,6 @@
 #ifndef FASTFLOAT_FLOAT_COMMON_H
 #define FASTFLOAT_FLOAT_COMMON_H
 
-#include <algorithm>
 #include <cfloat>
 #include <cstddef>
 #include <cstdint>
@@ -399,7 +398,7 @@ fastfloat_strncasecmp(UC const *actual_mixedcase, UC const *expected_lowercase,
     size_t sz{8 / (sizeof(UC))};
     for (size_t i = 0; i < length; i += sz) {
       val1 = val2 = 0;
-      sz = std::min(sz, length - i);
+      sz = sz < (length - i) ? sz : length - i;
       ::memcpy(&val1, actual_mixedcase + i, sz * sizeof(UC));
       ::memcpy(&val2, expected_lowercase + i, sz * sizeof(UC));
       val1 |= mask;

--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -1,6 +1,7 @@
 #ifndef FASTFLOAT_FLOAT_COMMON_H
 #define FASTFLOAT_FLOAT_COMMON_H
 
+#include <algorithm>
 #include <cfloat>
 #include <cstddef>
 #include <cstdint>


### PR DESCRIPTION
`fastfloat_strncasecmp` relies on `std::min`.