### PR TITLE
Unroll the integer-part digit scan (straight-line for the common 1-5 digit case)

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -354,13 +354,36 @@ parse_number_string(UC const *p, UC const *pend,
 
   uint64_t i = 0; // an unsigned int avoids signed overflows (which are bad)
 
-  while ((p != pend) && is_integer(*p)) {
-    // a multiplication by 10 is cheaper than an arbitrary integer
-    // multiplication
-    i = 10 * i +
-        uint64_t(*p -
-                 UC('0')); // might overflow, we will handle the overflow later
+  // Straight-line unroll of the integer-part scan: most integer parts are
+  // 1-5 digits, so peeling the first iterations eliminates the loop back-edge
+  // for the common case. Semantics are identical to the original `while` loop:
+  // i = 10*i + digit, advancing p.
+  if ((p != pend) && is_integer(*p)) {
+    i = uint64_t(*p - UC('0'));
     ++p;
+    if ((p != pend) && is_integer(*p)) {
+      i = 10 * i + uint64_t(*p - UC('0'));
+      ++p;
+      if ((p != pend) && is_integer(*p)) {
+        i = 10 * i + uint64_t(*p - UC('0'));
+        ++p;
+        if ((p != pend) && is_integer(*p)) {
+          i = 10 * i + uint64_t(*p - UC('0'));
+          ++p;
+          if ((p != pend) && is_integer(*p)) {
+            i = 10 * i + uint64_t(*p - UC('0'));
+            ++p;
+            while ((p != pend) && is_integer(*p)) {
+              // a multiplication by 10 is cheaper than an arbitrary integer
+              // multiplication
+              i = 10 * i +
+                  uint64_t(*p - UC('0')); // might overflow, handled later
+              ++p;
+            }
+          }
+        }
+      }
+    }
   }
   UC const *const end_of_integer_part = p;
   int64_t digit_count = int64_t(end_of_integer_part - start_digits);


### PR DESCRIPTION
The integer part of a number is scanned one byte at a time, while the fractional
part already uses the 8-digit SWAR loop (`loop_parse_if_eight_digits`). Integer parts
are usually short (1–5 digits), so the loop back-edge is a large share of the cost.
This peels the first five iterations into straight-line `if`s and falls through to the
original loop for longer inputs. The arithmetic is unchanged (`i = 10*i + digit`), so
behavior is identical; one file, +29/−6, in the `UC`-templated path.

Benchmark — `m8g.metal-24xl` (Graviton4), `-O3 -march=native`,
`simple_fastfloat_benchmark`, `from_chars`→`double`, base vs patch measured
back-to-back (mean of 2 runs):

| dataset | gcc 13 | clang 18 |
|---------|-------:|---------:|
| canada.txt | +3.1% | +2.8% |
| mesh.txt | +5.4% | +5.1% |
| random [0,1] | ~0% | ~0% |

random is `0.xxx` (a 1-digit integer part), so it is unaffected, as expected. No
regression on any input.

For completeness I also tried reusing `loop_parse_if_eight_digits` for the integer
part, and a counted `for (k < 5)` loop; both were slower here (the 8-digit SWAR setup
does not pay off for short integer parts, and clang optimized the counted loop less
well), so this keeps the explicit peel.

Tests: `FASTFLOAT_TEST` 14/14 and `FASTFLOAT_EXHAUSTIVE` (exhaustive32 / 32_64 /
midpoint / long variants) all pass. Builds clean on gcc and clang at C++11 and C++20
under `-Werror -Wall -Wextra -Weffc++ -Wconversion -Wsign-conversion -Wshadow`,
clang-format clean. No new multi-byte reads, so big-endian (s390x) is unaffected.
