### PR TITLE
Fix compile error in clang<10: fails on pragma -Wc++20-extensions

### DIFF
--- a/include/fast_float/parse_number.h
+++ b/include/fast_float/parse_number.h
@@ -358,7 +358,9 @@ from_chars_float_advanced(UC const *first, UC const *last, T &value,
 // This is unfortunate.
 #ifdef __clang__
 #pragma clang diagnostic push
+#if (!defined(__APPLE_CC__) && __clang_major__ >= 10) || (__clang_major__ >= 13)
 #pragma clang diagnostic ignored "-Wc++20-extensions"
+#endif
 #endif
   if fastfloat_unlikely (pns.too_many_digits) {
     return parse_number_slow_path<T, UC>(first, last, value, options, bjf);


### PR DESCRIPTION
This fixes a compile error introduced in #387. 

The error happens in all clang versions below 10, and is triggered by the use of the pragma ignore with what is an unknown warning on those compilers:

```
parse_number.h:361:34: error: unknown warning group '-Wc++20-extensions'
```

The fix requires looking at `__clang_major__`, which is unfortunately different in Apple, so a version dispatch is required.
