### PR TITLE
Remove an unreachable return statement

### DIFF
--- a/tests/fixedwidthtest.cpp
+++ b/tests/fixedwidthtest.cpp
@@ -65,6 +65,4 @@ int main() {
 #endif
   std::cout << "All tests passed successfully." << std::endl;
   return EXIT_SUCCESS;
-
-  return 0;
 }


### PR DESCRIPTION
The redundant statement was reported by cppcheck.

```
tests/fixedwidthtest.cpp:69:3: Consecutive return, break, continue, goto or throw statements are unnecessary.
```