### PR TITLE
Remove an else if statement that is always false

### DIFF
--- a/tests/long_exhaustive32_64.cpp
+++ b/tests/long_exhaustive32_64.cpp
@@ -45,11 +45,6 @@ void all_32bit_values() {
         std::cerr << "I got " << std::hexfloat << result_value
                   << " but I was expecting " << v << std::endl;
         abort();
-      } else if (std::isnan(v)) {
-        if (!std::isnan(result_value)) {
-          std::cerr << "not nan" << buffer << std::endl;
-          abort();
-        }
       } else if (result_value != v) {
         std::cerr << "no match ? " << buffer << std::endl;
         std::cout << "started with " << std::hexfloat << v << std::endl;


### PR DESCRIPTION
Commit b334317d added the same `std::isnan(v)` check as an earlier condition.

The warning was reported by cppcheck.

```
tests/long_exhaustive32_64.cpp:48:28: Expression is always false because 'else if' condition matches previous condition at line 39.
```