### PR TITLE
reject non-digit wide code units in uint8/uint16 integer fast path

### DIFF
--- a/include/fast_float/ascii_number.h
+++ b/include/fast_float/ascii_number.h
@@ -600,7 +600,8 @@ parse_int_string(UC const *p, UC const *pend, T &value,
 
   UC const *const start_digits = p;
 
-  FASTFLOAT_IF_CONSTEXPR17((std::is_same<T, std::uint8_t>::value)) {
+  FASTFLOAT_IF_CONSTEXPR17((std::is_same<T, std::uint8_t>::value &&
+                            sizeof(UC) == 1)) {
     if (base == 10) {
       const size_t len = (size_t)(pend - p);
       if (len == 0) {
@@ -692,7 +693,8 @@ parse_int_string(UC const *p, UC const *pend, T &value,
     }
   }
 
-  FASTFLOAT_IF_CONSTEXPR17((std::is_same<T, std::uint16_t>::value)) {
+  FASTFLOAT_IF_CONSTEXPR17((std::is_same<T, std::uint16_t>::value &&
+                            sizeof(UC) == 1)) {
     if (base == 10) {
       const size_t len = size_t(pend - p);
       if (len == 0) {

--- a/tests/fast_int.cpp
+++ b/tests/fast_int.cpp
@@ -1295,6 +1295,63 @@ int main() {
       return EXIT_FAILURE;
     }
   }
+  // The uint8_t and uint16_t base-10 paths use a byte-oriented fast path. A
+  // wider code unit whose low byte is an ASCII digit (e.g. U+2131..U+2139) must
+  // not be mistaken for that digit. The generic path already rejects these for
+  // int; the fixed-width fast paths must agree. Lengths of 1..5 exercise both
+  // the uint8_t path and the 4-digit uint16_t SWAR path.
+  {
+    const std::u16string bad16[] = {
+        u"ℹ",
+        u"ℱℲ",
+        u"ℱℲℳ",
+        u"ℱℲℳℴ",
+        u"ℱℲℳℴℵ",
+    };
+    const std::u32string bad32[] = {
+        U"ℹ",
+        U"ℱℲℳ",
+        U"ℱℲℳℴ",
+        U"ℱℲℳℴℵ",
+    };
+    bool failed = false;
+    for (auto const &s : bad16) {
+      uint8_t r8 = 123;
+      auto a8 = fast_float::from_chars(s.data(), s.data() + s.size(), r8);
+      if (a8.ec == std::errc()) {
+        failed = true;
+        std::cerr << "Incorrectly parsed wide units as uint8_t " << unsigned(r8)
+                  << "." << std::endl;
+      }
+      uint16_t r16 = 123;
+      auto a16 = fast_float::from_chars(s.data(), s.data() + s.size(), r16);
+      if (a16.ec == std::errc()) {
+        failed = true;
+        std::cerr << "Incorrectly parsed wide units as uint16_t " << r16 << "."
+                  << std::endl;
+      }
+    }
+    for (auto const &s : bad32) {
+      uint8_t r8 = 123;
+      auto a8 = fast_float::from_chars(s.data(), s.data() + s.size(), r8);
+      if (a8.ec == std::errc()) {
+        failed = true;
+        std::cerr << "Incorrectly parsed wide units as uint8_t " << unsigned(r8)
+                  << "." << std::endl;
+      }
+      uint16_t r16 = 123;
+      auto a16 = fast_float::from_chars(s.data(), s.data() + s.size(), r16);
+      if (a16.ec == std::errc()) {
+        failed = true;
+        std::cerr << "Incorrectly parsed wide units as uint16_t " << r16 << "."
+                  << std::endl;
+      }
+    }
+
+    if (failed) {
+      return EXIT_FAILURE;
+    }
+  }
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
While checking the fixed-width integer paths in `parse_int_string`, I noticed the `uint8_t` and `uint16_t` base-10 fast paths read code units byte-wise (a four-byte `memcpy` for `uint8_t`, `read4_to_u32` for `uint16_t`) and only ever look at the low byte. For `wchar_t`/`char16_t`/`char32_t` that means a non-digit code point whose low byte falls in `0x30`..`0x39`, say U+2131 through U+2139, is taken for the matching ASCII digit, so `from_chars(u"ℱℲℳℴ", v, 10)` returns 1234 with `std::errc()` where it ought to fail. The generic `ch_to_digit` loop already masks anything above `0xFF` and rejects these (the existing emoji tests confirm that for `int`), so the fast paths quietly disagree with the rest of the library and with `std::from_chars` semantics.

The byte-oriented SWAR is only sound when a code unit is a single byte, so both fast paths are now gated on `sizeof(UC) == 1` and wider units fall through to the generic loop that already handles them. Keeping the guard at the fast-path entry leaves the byte assumption and the digit validation in one place rather than re-checking after a truncating read. Left alone this is a silent input-validation hole for anyone feeding untrusted UTF-16/UTF-32 into 8- or 16-bit integers. I added the wide-unit cases to `tests/fast_int.cpp`; they parse as valid before the change and are rejected after it.