### PR TITLE
Fix compile error with gcc 9: use of [[unlikely]]

### DIFF
--- a/include/fast_float/float_common.h
+++ b/include/fast_float/float_common.h
@@ -207,7 +207,11 @@ using parse_options = parse_options_t<char>;
 // to a no-op elsewhere (e.g. pre-C++20 MSVC, which has no equivalent hint).
 #ifdef __has_cpp_attribute
 #if __has_cpp_attribute(unlikely) >= 201803L
-#define FASTFLOAT_USE_UNLIKELY_ATTR 1
+// g++-9 hits hits this branch, but then fails to compile
+// [[unlikely]]. This happens only with g++-9.
+#if !defined(__GNUC__) || (__GNUC__ != 9)
+#define FASTFLOAT_USE_UNLIKELY_ATTR
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
gcc 9 (and only 9) advertises availability of `[[unlikely]]` but then fails to compile it. Fixed by selectively disabling on gcc 9. With this change, now fast_float compiles in all existing gcc and clang versions.

Also, removed the value of 1 from `#define FAST_FLOAT_USE_UNLIKELY_ATTR 1`, to avoid erroneous hint to subsequent use of `#if` instead of `#ifdef`.